### PR TITLE
Move Shotgun Toolkit hooks into it's own repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,20 +1,15 @@
-name: Shotgun Toolkit
+name: CI
 on:
-  # Do not run if Docker image has been updated
-  pull_request:
-    paths:
-      - 'src/support/shotgun_toolkit/**'
-  push:
-    paths:
-      - 'src/support/shotgun_toolkit/**'
+- pull_request
+- push
 
 jobs:
   app-launch-hook:
     name: App Launch Hook - ${{ matrix.tk-config }}
     runs-on: ubuntu-latest
     env:
-      EXAMPLE_PATCH_PATH: "src/support/shotgun_toolkit/${{ matrix.tk-config }}/example-configs.patch"
-      SRC_HOOK_PATH: "src/support/shotgun_toolkit/${{ matrix.tk-config }}/${{ matrix.hook-path }}/rez_app_launch.py"
+      EXAMPLE_PATCH_PATH: "${{ matrix.tk-config }}/example-configs.patch"
+      SRC_HOOK_PATH: "${{ matrix.tk-config }}/${{ matrix.hook-path }}/rez_app_launch.py"
       SRC_URL: "https://github.com/shotgunsoftware/${{ matrix.tk-config }}/archive/${{ matrix.config-release }}.tar.gz"
 
     strategy:

--- a/.github/workflows/shotgun_toolkit.yaml
+++ b/.github/workflows/shotgun_toolkit.yaml
@@ -1,0 +1,56 @@
+name: Shotgun Toolkit
+on:
+  # Do not run if Docker image has been updated
+  pull_request:
+    paths:
+      - 'src/support/shotgun_toolkit/**'
+  push:
+    paths:
+      - 'src/support/shotgun_toolkit/**'
+
+jobs:
+  app-launch-hook:
+    name: App Launch Hook - ${{ matrix.tk-config }}
+    runs-on: ubuntu-latest
+    env:
+      EXAMPLE_PATCH_PATH: "src/support/shotgun_toolkit/${{ matrix.tk-config }}/example-configs.patch"
+      SRC_HOOK_PATH: "src/support/shotgun_toolkit/${{ matrix.tk-config }}/${{ matrix.hook-path }}/rez_app_launch.py"
+      SRC_URL: "https://github.com/shotgunsoftware/${{ matrix.tk-config }}/archive/${{ matrix.config-release }}.tar.gz"
+
+    strategy:
+      matrix:
+        tk-config:
+          - 'tk-config-default'
+          - 'tk-config-default2'
+        include:
+          - tk-config: 'tk-config-default'
+            hook-path: 'hooks'
+            config-release: 'v0.18.2'
+          - tk-config: 'tk-config-default2'
+            hook-path: 'hooks/tk-multi-launchapp'
+            config-release: 'v1.2.11'
+
+      fail-fast: false
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Download ${{matrix.tk-config}}
+        run: |
+          mkdir -vp "${{ runner.temp }}"
+          curl -sSL "$SRC_URL" \
+            | tar -C "${{ runner.temp }}" --strip-components=1 -xz
+
+      - name: Install Hook
+        run: |
+          set -x
+          test -f "$GITHUB_WORKSPACE/$SRC_HOOK_PATH"
+          cp -v "$GITHUB_WORKSPACE/$SRC_HOOK_PATH" "${{ runner.temp }}/${{ matrix.hook-path }}/rez_app_launch.py"
+
+      - name: Check .patch works
+        run: |
+          set -x -o pipefail
+          cd "${{ runner.temp }}"
+          test -f "$GITHUB_WORKSPACE/$EXAMPLE_PATCH_PATH"
+          patch --strip=0 --verbose < "$GITHUB_WORKSPACE/$EXAMPLE_PATCH_PATH"

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -1,0 +1,16 @@
+Mostly pulled from `git log`:
+
+# Original tk-config-default version
+
+- [Allan Johns](https://github.com/nerdvegas)
+- [Renaud Lessard Larouche](https://github.com/renaudll)
+- [Brendan Abel](https://github.com/bpabel)
+- [Sebastian Kral](https://github.com/skral)
+
+# tk-config-default2 version
+
+This version is copied and refactored from the original `tk-config-default`
+version to work with `tk-config-default2` by:
+
+- [Liam Hoflay](https://github.com/liametc)
+- [Joseph Yu](https://github.com/j0yu)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `rez_app_launch.py` hooks per `tk-config-default*` configurations.
+- `tk-config-default*/env/**` example configurations folders.
+- GitHub CI workflow to test patching/installing against 
+  official Shotgun `tk-config-default*`

--- a/README.md
+++ b/README.md
@@ -1,2 +1,251 @@
-# rez-shotgun
-Rez extension for Shotgun Toolkit
+# App Launch Hook - Rez
+
+This hook is executed to launch applications, potentially in a Rez context.
+
+It is **NOT** official/supported by Shotgun Software, but by
+[third-party contributors](/AUTHORS.md)
+
+Please note that this requires Rez to be installed as a package, i.e.
+able to `rez env rez`, which exposes the Rez Python API.
+
+With a proper Rez installation, you can do this by running `rez-bind rez`.
+
+
+To keep a copy of the original `rez_app_launch.py`, there are 2 variants
+available:
+
+- [tk-config-default2][] is the latest pipeline configuration style
+
+  - Currently supported by Shotgun Software
+  - Will be targeting this going forward for `rez_app_launch.py`
+
+- [tk-config-default][] is the legacy pipeline configuration style
+
+  - Less supported by Shotgun Software
+  - The original `rez_app_launch.py`, only updated to keep it functional
+
+> As of writing, the 2 `rez_app_launch.py` was tested at [WWFX UK][]
+> using [rez 2.28.0][]. Newer `rez` versions may be tested in the future.
+
+
+
+## Installation
+
+1. Setup custom pipeline configuration for your Shotgun project
+
+   See ["Advanced project setup" steps](https://youtu.be/7qZfy7KXXX0?t=1170)
+   video or checkout [this official tutorial page](https://developer.shotgunsoftware.com/5d83a936/#accessing-the-default-configuration)
+
+1. Identify whether your pipeline configurations are based off
+   [tk-config-default2][] or [tk-config-default][] (legacy)
+
+The Python hook and example `.yml` configuration files are setup in a way
+that mimics the folder structure where you need to copy them into.
+
+`<config>` will now refer to the full path to the folder which contain
+`core`, `env`, `hooks`.
+
+See [this point in this video](https://youtu.be/7qZfy7KXXX0?t=2434)
+
+
+### tk-config-default2
+
+1. Create `<config>/hooks/tk-multi-launchapp` folder if it does not exist.
+1. Copy `tk-config-default2/hooks/tk-multi-launchapp/rez_app_launch.py`
+   into that folder.
+
+
+### tk-config-default (legacy)
+
+1. Create `<config>/hooks` folder if it does not exist (highly unlikely).
+1. Copy `tk-config-default2/hooks/rez_app_launch.py` into that folder.
+
+
+## Usage
+
+After setting up the advanced pipeline configurations and copying in the
+Python hook file, setting up applications to be launched from Rez are done by:
+
+1. Defining applications to be launched
+1. Exposing those applications to be launched in various Shotgun *apps*
+
+Then, you should be able to see and launch applications in rez context in:
+
+- **Shotgun Create** app: setup by [tk-desktop2][]
+- **Shotgun Desktop** app: setup by [tk-desktop][]
+- Menus in the **Shotgun Website**: setup by [tk-shotgun][]
+- **Shotgun Shell**: setup by [tk-shell][]
+
+### tk-config-default2
+
+If you are using [tk-config-default2 v1.2.11][] and have the [patch][]
+program available, you can do these remaining steps by simply running
+in the terminal (tested on Linux):
+
+```bash
+patch --strip=0 < tk-config-default2/example-configs.patch
+```
+
+It might work with other versions/permutations of pipeline configurations
+but not guaranteed.
+
+Otherwise, manually...
+
+1. Create new `settings.tk-tk-multi-launchapp.*` application configurations
+   inside `<config>/env/includes/settings/tk-multi-launchapp.yml`.
+
+   Here is an **example** for Maya. This assumes you have a `maya` rez package
+   built, installed and available i.e. `rez env maya`.
+
+   ```yaml
+   # rez Maya 2019
+   settings.tk-multi-launchapp.maya:
+     engine: tk-maya
+     extra:
+       rez:
+         packages:
+         - maya-2019
+         # # Optional, additional rez packages
+         # - studio_maya_tools-1.2
+         # - show_maya_tools-dev
+         parent_variables:
+         - PYTHONPATH
+         - MAYA_MODULE_PATH
+         - MAYA_SCRIPT_PATH
+     menu_name: "Maya 2019"
+     location: "@apps.tk-multi-launchapp.location"
+     # --- IMPORTANT ---
+     # Point to rez_app_launch.py hook location
+     hook_app_launch: "{config}/tk-multi-launchapp/rez_app_launch.py"
+     # What to run after entering "rez env maya" to launch Maya, e.g.
+     linux_path: "maya"
+     mac_path: "Maya.app"
+     windows_path: "maya.exe"
+   ```
+
+1. Expose those `settings.tk-tk-multi-launchapp.*` application configurations
+   for Shotgun *apps* which launches applications
+
+   i.e. inside `<config>/env/includes/settings/`:
+
+   <details><summary>tk-desktop.yml</summary>
+
+   ```yaml
+   settings.tk-desktop.project:
+     apps:
+       tk-multi-pythonconsole:
+         location: "@apps.tk-multi-pythonconsole.location"
+       tk-multi-devutils:
+         location: "@apps.tk-multi-devutils.location"
+       tk-multi-launchapp: "@settings.tk-multi-launchapp"
+       tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+       tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+       tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+   ```
+   </details>
+
+   <details><summary>tk-desktop2.yml</summary>
+
+   ```yaml
+   # project
+   settings.tk-desktop2.all:
+     apps:
+       tk-multi-launchapp: "@settings.tk-multi-launchapp"
+       tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+       tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+       tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+   ```
+   </details>
+
+   <details><summary>tk-shell.yml</summary>
+
+   ```yaml
+   # Same for other settings.tk-shell.*
+   settings.tk-shell.asset:
+     apps:
+       tk-multi-launchapp: '@settings.tk-multi-launchapp'
+       tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+       tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+   ```
+   </details>
+
+   <details><summary>tk-shotgun.yml</summary>
+
+   ```yaml
+   # Same for other settings.tk-shotgun.*
+   settings.tk-shotgun.asset:
+     apps:
+       tk-multi-launchapp: "@settings.tk-multi-launchapp"
+       tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+       tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+   ```
+   </details>
+
+### tk-config-default (legacy)
+
+If you are using [tk-config-default v0.18.2][] and have the [patch][]
+program available, you can do these remaining steps by simply running
+in the terminal (tested on Linux):
+
+```bash
+patch --strip=0 < tk-config-default/example-configs.patch
+```
+
+It might work with other versions/permutations of pipeline configurations
+but not guaranteed.
+
+Otherwise, manually...
+
+1. Create new application configurations inside, e.g. "launch_rez_maya_2019"
+   `<config>/env/includes/app_launchers.yml`.
+
+   Here is an **example** for Maya. This assumes you have a `maya` rez package
+   built, installed and available i.e. `rez env maya`.
+
+   ```yaml
+   #
+   # -------------------------------------------------
+   # rez Maya 2019
+   # -------------------------------------------------
+   launch_rez_maya_2019:
+     engine: tk-maya
+     extra:
+       rez_packages:
+       - maya-2019
+       # # Optional, additional rez packages
+       # - studio_maya_tools-1.2
+       # - show_maya_tools-dev
+     hook_app_launch: rez_app_launch
+     hook_before_app_launch: default
+     icon: '{target_engine}/icon_256.png'
+     linux_path: "maya"
+     location:
+       version: v0.9.15
+       type: app_store
+       name: tk-multi-launchapp
+     mac_path: "Maya.app"
+     menu_name: Rez Maya 2019
+     windows_path: "maya.exe"
+   ```
+
+1. Expose those application configurations for Shotgun environment/*apps*
+   which launches applications.
+
+   i.e. inside `<config>/env/`, look for usages of "launch_maya" and create
+   a copy of it but for "launch_rez_maya_2019"
+
+   Check out the `tk-config-default/env/*.yml` example configuration files for
+   more info.
+
+[patch]: https://www.gnu.org/software/diffutils/manual/html_mono/diff.html#Invoking%20patch
+[rez 2.28.0]: https://github.com/nerdvegas/rez/releases/tag/2.28.0
+[tk-desktop2]: https://github.com/shotgunsoftware/tk-desktop2
+[tk-desktop]: https://github.com/shotgunsoftware/tk-desktop
+[tk-shotgun]: https://github.com/shotgunsoftware/tk-shotgun
+[tk-shell]: https://github.com/shotgunsoftware/tk-shell
+[tk-config-default]: https://github.com/shotgunsoftware/tk-config-default
+[tk-config-default v0.18.2]: https://github.com/shotgunsoftware/tk-config-default/releases/tag/v0.18.2
+[tk-config-default2]: https://github.com/shotgunsoftware/tk-config-default2
+[tk-config-default2 v1.2.11]: https://github.com/shotgunsoftware/tk-config-default2/releases/tag/v1.2.11
+[WWFX UK]: https://github.com/wwfxuk

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # App Launch Hook - Rez
 
+[![CI](https://github.com/nerdvegas/rez-shotgun/workflows/CI/badge.svg?branch=master)](https://github.com/nerdvegas/rez-shotgun/actions?query=workflow%3ACI+branch%3Amaster)
+
+
 This hook is executed to launch applications, potentially in a Rez context.
 
 It is **NOT** official/supported by Shotgun Software, but by

--- a/tk-config-default/env/asset.yml
+++ b/tk-config-default/env/asset.yml
@@ -1,0 +1,242 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Apps and engines loaded when an Asset is loaded. Since std VFX config
+  template has a file system structure which is centered around pipeline steps, this
+  environment is largely empty. Most of the work takes place on a level in the file
+  system where both an asset and a pipeline step is available - e.g Asset Hero, modeling,
+  so all apps for loading, publishing etc. are located in the asset_step environment.
+  This environment mostly contains utility apps and the tank work files app, which
+  lets you choose a task to work on and load associated content into an application.
+
+#################################################################################################
+# include common files
+includes:
+# launchers for launching DCCs such as Maya, Nuke etc.
+- ./includes/app_launchers.yml
+# common app configurations that are reused across environments
+- ./includes/common_apps.yml
+
+#################################################################################################
+# define all the items that should appear in this environment
+
+
+
+engines:
+  #
+  # -------------------------------------------------
+  # 3dsmax plus
+  # -------------------------------------------------
+  tk-3dsmaxplus:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 2017
+    debug_logging: false
+    location:
+      version: v0.5.1
+      type: app_store
+      name: tk-3dsmaxplus
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Houdini
+  # -------------------------------------------------
+  tk-houdini:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    location:
+      version: v1.3.0
+      type: app_store
+      name: tk-houdini
+    enable_sg_shelf: true
+    debug_logging: false
+    enable_sg_menu: true
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Mari
+  # -------------------------------------------------
+  tk-mari:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-workfiles:
+        allow_task_creation: true
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        launch_change_work_area_at_startup: false
+        location:
+          version: v0.7.4
+          type: app_store
+          name: tk-multi-workfiles
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        sg_entity_type_extra_display_fields: {}
+        sg_entity_type_filters: {}
+        sg_entity_types: [Asset]
+        sg_task_filters: []
+        task_extra_display_fields: []
+        template_publish:
+        template_publish_area:
+        template_work:
+        template_work_area:
+        version_compare_ignore_fields: []
+    compatibility_dialog_min_version: 2
+    debug_logging: false
+    location:
+      version: v1.2.0
+      type: app_store
+      name: tk-mari
+  #
+  # -------------------------------------------------
+  # Maya
+  # -------------------------------------------------
+  tk-maya:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2-launch-at-startup'
+    compatibility_dialog_min_version: 2015
+    debug_logging: false
+    location:
+      version: v0.9.1
+      type: app_store
+      name: tk-maya
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Motionbuilder
+  # -------------------------------------------------
+  tk-motionbuilder:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.4.0
+      type: app_store
+      name: tk-motionbuilder
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Nuke
+  # -------------------------------------------------
+  tk-nuke:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    favourite_directories: []
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    bin_context_menu: []
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+  #
+  # -------------------------------------------------
+  # Photoshop CC
+  # -------------------------------------------------
+  tk-photoshopcc:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    shelf_favorites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    debug_logging: false
+    location:
+      version: v1.2.1
+      type: app_store
+      name: tk-photoshopcc
+  #
+  # -------------------------------------------------
+  # Shell
+  # -------------------------------------------------
+  tk-shell:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-launchmari: '@launch_mari'
+    location:
+      version: v0.6.0
+      type: app_store
+      name: tk-shell
+  #
+  # -------------------------------------------------
+  # Softimage
+  # -------------------------------------------------
+  tk-softimage:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.3.4
+      type: app_store
+      name: tk-softimage
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks:
+  tk-framework-softimageqt_v1.0.1:
+    location:
+      name: tk-framework-softimageqt
+      type: app_store
+      version: v1.0.1

--- a/tk-config-default/env/asset_step.yml
+++ b/tk-config-default/env/asset_step.yml
@@ -1,0 +1,1533 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+#
+description: Apps and Engines related to Asset based work.
+
+#################################################################################################
+# include common files
+
+includes:
+# launchers for launching DCCs such as Maya, Nuke etc.
+- ./includes/app_launchers.yml
+# common app configurations that are reused across environments
+- ./includes/common_apps.yml
+
+
+#################################################################################################
+# define all the items that should appear in this environment
+
+engines:
+  #
+  # -------------------------------------------------
+  # 3dsmax Plus
+  # -------------------------------------------------
+  tk-3dsmaxplus:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-loader2:
+        action_mappings:
+          3dsmax Scene: [import, reference]
+          Alembic Cache: [import]
+        actions_hook: '{self}/tk-3dsmaxplus_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current 3ds Max scene
+        primary_display_name: 3ds Max Publish
+        primary_icon: icons/publish_3dsmax_main.png
+        primary_publish_template: max_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: 3dsmax Scene
+        secondary_outputs:
+        - description: Publish Alembic data for all geometry in the scene
+          display_group: Geometry Caches
+          display_name: Alembic Caches
+          icon: icons/alembic_cache_publish.png
+          name: alembic_cache
+          publish_template: asset_alembic_cache
+          required: false
+          scene_item_type: geometry
+          selected: false
+          tank_type: Alembic Cache
+        template_work: max_asset_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: max_asset_snapshot
+        template_work: max_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: max_asset_publish
+        template_publish_area: asset_publish_area_max
+        template_work: max_asset_work
+        template_work_area: asset_work_area_max
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    compatibility_dialog_min_version: 2017
+    debug_logging: false
+    location:
+      version: v0.5.1
+      type: app_store
+      name: tk-3dsmaxplus
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Houdini
+  # -------------------------------------------------
+  tk-houdini:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current scene
+        primary_display_name: Scene File Publish
+        primary_icon: icons/publish_houdini_main.png
+        primary_publish_template: houdini_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Houdini Scene
+        secondary_outputs:
+        - description: Publish Alembic Cache data for the model
+          display_group: Caches
+          display_name: Alembic Cache
+          group_name: Alembic Caches
+          icon: icons/alembic_cache_publish.png
+          name: alembic_cache
+          publish_group: true
+          publish_template: houdini_asset_work_alembic_cache
+          required: false
+          scene_item_type: alembic_cache
+          selected: false
+          tank_type: Alembic Cache
+        - description: Publish a rendered image sequence
+          display_group: Renders
+          display_name: Rendered
+          group_name: default
+          icon: icons/publish_houdini_renders.png
+          name: rendered_image
+          publish_group: false
+          publish_template: houdini_asset_render
+          required: false
+          scene_item_type: rendered_image
+          selected: false
+          tank_type: Rendered Image
+        template_work: houdini_asset_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: houdini_asset_snapshot
+        template_work: houdini_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: houdini_asset_publish
+        template_publish_area: asset_publish_area_houdini
+        template_work: houdini_asset_work
+        template_work_area: asset_work_area_houdini
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+        actions_hook: '{self}/general_actions.py'
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+      tk-houdini-alembicnode:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-houdini-alembicnode
+        work_file_template: houdini_asset_work
+        default_node_name: sg_alembic_out
+        output_profiles:
+        - name: Shot Work Cache
+          settings: {}
+          color: []
+          output_cache_template: houdini_asset_work_alembic_cache
+      tk-houdini-mantranode:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-houdini-mantranode
+        work_file_template: houdini_asset_work
+        default_node_name: sg_mantra_out
+        output_profiles:
+        - name: Default Render
+          settings: {}
+          color: []
+          output_render_template: houdini_asset_render
+          output_ifd_template: houdini_asset_ifd
+          output_dcm_template: houdini_asset_dcm
+          output_extra_plane_template: houdini_asset_extra_plane
+      tk-multi-loader2:
+        action_mappings:
+          Alembic Cache: [import]
+        actions_hook: '{self}/tk-houdini_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-houdini_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+    debug_logging: false
+    enable_sg_shelf: true
+    enable_sg_menu: true
+    location:
+      version: v1.3.0
+      type: app_store
+      name: tk-houdini
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+  #
+  # -------------------------------------------------
+  # Mari
+  # -------------------------------------------------
+  tk-mari:
+    apps:
+      tk-mari-projectmanager:
+        default_project_name: Shotgun
+        get_project_creation_args_hook: '{self}/get_project_creation_args.py'
+        location:
+          version: v1.2.0
+          type: app_store
+          name: tk-mari-projectmanager
+        publish_types: [Alembic Cache]
+        template_new_project_name: mari_asset_project_name
+        post_project_creation_hook: '{self}/post_project_creation.py'
+      tk-multi-about: '@about'
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-mari_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Alembic Cache: [geometry_import]
+        actions_hook: '{self}/tk-mari_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+          publish_filters: []
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+          publish_filters: []
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Import
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: true
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish items from the current Mari project
+        primary_display_name: Mari Publish
+        primary_icon: icons/publish_mari_main.png
+        primary_publish_template:
+        primary_scene_item_type: work_file
+        primary_tank_type: Mari Scene
+        secondary_outputs:
+        - description: Publish flattened channels
+          display_group: Texture Channels
+          display_name: Channels
+          icon: icons/mari_channel_publish.png
+          name: channel
+          publish_template: asset_mari_texture_tif
+          required: false
+          scene_item_type: channel
+          selected: false
+          tank_type: UDIM Image
+        - description: Publish individual layers for channels
+          display_group: Texture Channel Layers
+          display_name: Layers
+          icon: icons/mari_layer_publish.png
+          name: layer
+          publish_template: asset_mari_texture_tif
+          required: false
+          scene_item_type: layer
+          selected: false
+          tank_type: UDIM Image
+        template_work:
+      tk-multi-workfiles:
+        allow_task_creation: true
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        launch_change_work_area_at_startup: false
+        location:
+          version: v0.7.4
+          type: app_store
+          name: tk-multi-workfiles
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        sg_entity_type_extra_display_fields: {}
+        sg_entity_type_filters: {}
+        sg_entity_types: [Asset]
+        sg_task_filters: []
+        task_extra_display_fields: []
+        template_publish:
+        template_publish_area:
+        template_work:
+        template_work_area:
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    compatibility_dialog_min_version: 2
+    debug_logging: false
+    location:
+      version: v1.2.0
+      type: app_store
+      name: tk-mari
+  #
+  # -------------------------------------------------
+  # Maya
+  # -------------------------------------------------
+  tk-maya:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-maya_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Maya Scene: [reference, import]
+          Photoshop Image: [texture_node]
+          Rendered Image: [texture_node]
+          UDIM Image: [udim_texture_node]
+        actions_hook: '{self}/tk-maya_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current Maya scene
+        primary_display_name: Maya Publish
+        primary_icon: icons/publish_maya_main.png
+        primary_publish_template: maya_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Maya Scene
+        secondary_outputs:
+        - description: Publish Alembic data for all geometry in the scene
+          display_group: Geometry Caches
+          display_name: Alembic Caches
+          icon: icons/alembic_cache_publish.png
+          name: alembic_cache
+          publish_template: asset_alembic_cache
+          required: false
+          scene_item_type: geometry
+          selected: false
+          tank_type: Alembic Cache
+        template_work: maya_asset_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [reference, import]
+            filters: {published_file_type: Maya Scene}
+          - actions: [texture_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [texture_node]
+            filters: {published_file_type: Photoshop Image}
+          - actions: [udim_texture_node]
+            filters: {published_file_type: UDIM Image}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-maya_actions.py'
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: maya_asset_snapshot
+        template_work: maya_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: maya_asset_publish
+        template_publish_area: asset_publish_area_maya
+        template_work: maya_asset_work
+        template_work_area: asset_work_area_maya
+        version_compare_ignore_fields: []
+    compatibility_dialog_min_version: 2015
+    debug_logging: false
+    location:
+      version: v0.9.1
+      type: app_store
+      name: tk-maya
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    template_project: asset_work_area_maya
+    use_sgtk_as_menu_name: false
+  #
+  # -------------------------------------------------
+  # Motionbuilder
+  # -------------------------------------------------
+  tk-motionbuilder:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-loader2:
+        action_mappings:
+          Motion Builder FBX: [import]
+        actions_hook: '{self}/tk-motionbuilder_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current work file
+        primary_display_name: Current Work File
+        primary_icon: icons/publish_motionbuilder_main.png
+        primary_publish_template: mobu_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Motion Builder FBX
+        secondary_outputs: []
+        template_work: mobu_asset_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: mobu_asset_snapshot
+        template_work: mobu_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: mobu_asset_publish
+        template_publish_area: asset_publish_area_mobu
+        template_work: mobu_asset_work
+        template_work_area: asset_work_area_mobu
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    debug_logging: false
+    location:
+      version: v0.4.0
+      type: app_store
+      name: tk-motionbuilder
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    use_sgtk_as_menu_name: false
+  #
+  # -------------------------------------------------
+  # Nuke
+  # -------------------------------------------------
+  tk-nuke:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Nuke Script: [script_import]
+          Rendered Image: [read_node]
+          Alembic Cache: [read_node]
+        actions_hook: '{self}/tk-nuke_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publishes and versions up the current Nuke script.
+        primary_display_name: Nuke Publish
+        primary_icon: icons/publish_nuke_main.png
+        primary_publish_template: nuke_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Nuke Script
+        secondary_outputs:
+        - description: Copy renders from work area to publish area.
+          display_group: Shotgun Write Nodes
+          display_name: Publish Renders and send to Screening Room
+          icon: icons/publish_nuke_writenode.png
+          name: render
+          publish_template:
+          required: false
+          scene_item_type: write_node
+          selected: true
+          tank_type: Rendered Image
+        - description: Create quicktime and send to Screening Room
+          display_group: Shotgun Write Nodes
+          display_name: Send to Screening Room
+          icon: icons/publish_nuke_review.png
+          name: quicktime
+          publish_template:
+          required: false
+          scene_item_type: write_node
+          selected: true
+          tank_type: Quicktime
+        template_work: nuke_asset_work
+      tk-multi-reviewsubmission:
+        location:
+          version: v0.3.2
+          type: app_store
+          name: tk-multi-reviewsubmission
+        movie_height: 540
+        movie_path_template: nuke_asset_render_movie
+        movie_width: 1024
+        new_version_status: rev
+        slate_logo: icons/review_submit_logo.png
+        store_on_disk: true
+        upload_to_shotgun: true
+        version_number_padding: 3
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [read_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [script_import]
+            filters: {published_file_type: Nuke Script}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: nuke_asset_snapshot
+        template_work: nuke_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: nuke_asset_publish
+        template_publish_area: asset_publish_area_nuke
+        template_work: nuke_asset_work
+        template_work_area: asset_work_area_nuke
+        version_compare_ignore_fields: []
+      tk-nuke-quickdailies:
+        current_scene_template: nuke_asset_work
+        height: 768
+        location:
+          version: v0.3.6
+          type: app_store
+          name: tk-nuke-quickdailies
+        movie_template: asset_quicktime_quick
+        post_hooks: [snapshot_history_post_quickdaily]
+        sg_version_name_template: nuke_quick_asset_version_name
+        width: 1024
+        upload_movie: true
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-nuke-writenode:
+        location:
+          version: v1.2.0
+          type: app_store
+          name: tk-nuke-writenode
+        template_script_work: nuke_asset_work
+        write_nodes:
+        - file_type: exr
+          name: Exr
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_asset_render_pub
+          render_template: nuke_asset_render
+          settings: {}
+          tank_type: Rendered Image
+          tile_color: []
+          promote_write_knobs: []
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    favourite_directories: []
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    bin_context_menu: []
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Nuke Studio
+  # -------------------------------------------------
+  tk-nukestudio:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish Project
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the selected Hiero project
+        primary_display_name: Hiero Publish
+        primary_icon: icons/publish_hiero_main.png
+        primary_publish_template: hiero_project_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Hiero Project
+        secondary_outputs: []
+        template_work: hiero_project_work
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: hiero_project_snapshot
+        template_work: hiero_project_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Projects
+          entity_type: Project
+          filters: []
+          hierarchy: [name]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: false
+        template_publish: hiero_project_publish
+        template_publish_area: hiero_project_publish_area
+        template_work: hiero_project_work
+        template_work_area: hiero_project_work_area
+        version_compare_ignore_fields: []
+      tk-nuke-quickdailies:
+        current_scene_template: nuke_shot_work
+        height: 768
+        location:
+          version: v0.3.6
+          type: app_store
+          name: tk-nuke-quickdailies
+        movie_template: shot_quicktime_quick
+        post_hooks: [snapshot_history_post_quickdaily]
+        sg_version_name_template: nuke_quick_shot_version_name
+        width: 1024
+        upload_movie: true
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-nuke-writenode:
+        location:
+          version: v1.2.0
+          type: app_store
+          name: tk-nuke-writenode
+        template_script_work: nuke_shot_work
+        write_nodes:
+        - file_type: exr
+          name: Stereo Exr, 32 bit
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_stereo
+          render_template: nuke_shot_render_stereo
+          settings:
+            datatype: 32 bit float
+          tank_type: Rendered Image
+          tile_color: []
+          promote_write_knobs: []
+        - file_type: exr
+          name: Stereo Exr, 16 bit
+          promote_write_knobs: []
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_stereo
+          render_template: nuke_shot_render_stereo
+          settings:
+            datatype: 16 bit half
+          tank_type: Rendered Image
+          tile_color: []
+        - file_type: dpx
+          name: Mono Dpx
+          promote_write_knobs: []
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_mono_dpx
+          render_template: nuke_shot_render_mono_dpx
+          settings: {}
+          tank_type: Rendered Image
+          tile_color: []
+      tk-multi-reviewsubmission:
+        location:
+          version: v0.3.2
+          type: app_store
+          name: tk-multi-reviewsubmission
+        movie_height: 540
+        movie_path_template: nuke_shot_render_movie
+        movie_width: 1024
+        new_version_status: rev
+        slate_logo: icons/review_submit_logo.png
+        store_on_disk: true
+        upload_to_shotgun: true
+        version_number_padding: 3
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          name: tk-multi-setframerange
+          type: app_store
+          version: v0.3.0
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Nuke Script: [script_import]
+          Rendered Image: [read_node]
+          Alembic Cache: [read_node]
+        actions_hook: '{self}/tk-nuke_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [read_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [script_import]
+            filters: {published_file_type: Nuke Script}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+    bin_context_menu:
+    - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
+      requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot..., requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot History...,
+      requires_selection: true}
+    - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
+      requires_selection: true}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    favourite_directories: []
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+  #
+  # -------------------------------------------------
+  # Photoshop CC
+  # -------------------------------------------------
+  tk-photoshopcc:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-loader2:
+        action_mappings:
+          Photoshop Image: [add_as_a_layer, open_file]
+          Rendered Image: [add_as_a_layer, open_file]
+        actions_hook: default
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current Photoshop scene
+        primary_display_name: Photoshop Publish
+        primary_icon: icons/publish_photoshop_main.png
+        primary_publish_template: photoshop_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Photoshop Image
+        secondary_outputs: []
+        template_work: photoshop_asset_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: photoshop_asset_snapshot
+        template_work: photoshop_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: photoshop_asset_publish
+        template_publish_area: asset_publish_area_photoshop
+        template_work: photoshop_asset_work
+        template_work_area: asset_work_area_photoshop
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    shelf_favorites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    debug_logging: false
+    location:
+      version: v1.2.1
+      type: app_store
+      name: tk-photoshopcc
+  #
+  # -------------------------------------------------
+  # Shell Engine (tank command)
+  # -------------------------------------------------
+  tk-shell:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+    location:
+      version: v0.6.0
+      type: app_store
+      name: tk-shell
+  #
+  # -------------------------------------------------
+  # Softimage
+  # -------------------------------------------------
+  tk-softimage:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current Softimage scene
+        primary_display_name: Softimage Publish
+        primary_icon: icons/publish_softimage_main.png
+        primary_publish_template: softimage_asset_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Softimage Scene
+        secondary_outputs: []
+        template_work: softimage_asset_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: softimage_asset_snapshot
+        template_work: softimage_asset_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: softimage_asset_publish
+        template_publish_area: asset_publish_area_softimage
+        template_work: softimage_asset_work
+        template_work_area: asset_work_area_softimage
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    debug_logging: false
+    location:
+      version: v0.3.4
+      type: app_store
+      name: tk-softimage
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    template_project: asset_work_area_softimage
+
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks:
+  tk-framework-softimageqt_v1.0.1:
+    location:
+      name: tk-framework-softimageqt
+      type: app_store
+      version: v1.0.1

--- a/tk-config-default/env/includes/app_launchers.yml
+++ b/tk-config-default/env/includes/app_launchers.yml
@@ -1,0 +1,363 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+#################################################################################################
+# include paths to all our applications
+includes:
+# first include the configuration's global settings for application paths
+- ./paths.yml
+- ./common_apps.yml
+
+# now include overrides - these will be loaded if they are found
+- sequences/{Sequence}/{Shot}/sgtk_overrides.yml
+- assets/{sg_asset_type}/{Asset}/sgtk_overrides.yml
+
+
+################################################################################################
+# app definitions for all the Sgtk app launchers.
+
+#
+# -------------------------------------------------
+# 3dsmax
+# -------------------------------------------------
+launch_3dsmax:
+  defer_keyword: ''
+  engine: tk-3dsmaxplus
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: ''
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: ''
+  menu_name: Launch 3dsmax # note: desktop app means we cannot have spaces in app name
+  versions: []
+  windows_args: ''
+  windows_path: '@3dsmax_windows'
+#
+# -------------------------------------------------
+# Flame
+# -------------------------------------------------
+launch_flame:
+  defer_keyword: ''
+  engine: tk-flame
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/flame_icon_256.png'
+  linux_args: ''
+  linux_path: '@flame_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@flame_mac'
+  menu_name: Launch Flame
+  versions: []
+  windows_args: ''
+  windows_path: ''
+#
+# -------------------------------------------------
+# Flame Assist
+# -------------------------------------------------
+launch_flame_assist:
+  defer_keyword: ''
+  engine: tk-flame
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/flame_assist_icon_256.png'
+  linux_args: ''
+  linux_path: '@flame_assist_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@flame_assist_mac'
+  menu_name: Launch FlameAssist
+  versions: []
+  windows_args: ''
+  windows_path: ''
+#
+# -------------------------------------------------
+# Flare
+# -------------------------------------------------
+launch_flare:
+  defer_keyword: ''
+  engine: tk-flare
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/flare_icon_256.png'
+  linux_args: ''
+  linux_path: '@flare_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@flare_mac'
+  menu_name: Launch Flare
+  versions: []
+  windows_args: ''
+  windows_path: ''
+#
+# -------------------------------------------------
+# Hiero
+# -------------------------------------------------
+launch_hiero:
+  defer_keyword: ''
+  engine: tk-hiero
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_hiero_256.png'
+  linux_args: --hiero
+  linux_path: '@hiero_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@hiero_mac'
+  menu_name: Launch Hiero
+  versions: []
+  windows_args: --hiero
+  windows_path: '@hiero_win'
+#
+# -------------------------------------------------
+# Houdini
+# -------------------------------------------------
+launch_houdini:
+  defer_keyword: ''
+  engine: tk-houdini
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: '@houdini_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@houdini_mac'
+  menu_name: Launch Houdini
+  versions: []
+  windows_args: ''
+  windows_path: '@houdini_windows'
+#
+# -------------------------------------------------
+# Mari
+# -------------------------------------------------
+launch_mari:
+  defer_keyword: ''
+  engine: tk-mari
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: '@mari_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@mari_mac'
+  menu_name: Launch Mari
+  versions: []
+  windows_args: ''
+  windows_path: '@mari_windows'
+#
+# -------------------------------------------------
+# Maya
+# -------------------------------------------------
+launch_maya:
+  defer_keyword: ''
+  engine: tk-maya
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: '@maya_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@maya_mac'
+  menu_name: Launch Maya
+  versions: []
+  windows_args: ''
+  windows_path: '@maya_windows'
+#
+# -------------------------------------------------
+# Motionbuilder
+# -------------------------------------------------
+launch_motionbuilder:
+  defer_keyword: ''
+  engine: tk-motionbuilder
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: ''
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: ''
+  menu_name: Launch MotionBuilder
+  versions: []
+  windows_args: ''
+  windows_path: '@motionbuilder_windows'
+#
+# -------------------------------------------------
+# Nuke
+# -------------------------------------------------
+launch_nuke:
+  defer_keyword: ''
+  engine: tk-nuke
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: '@nuke_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@nuke_mac'
+  menu_name: Launch Nuke
+  versions: []
+  windows_args: ''
+  windows_path: '@nuke_windows'
+#
+# -------------------------------------------------
+# Nuke Studio
+# -------------------------------------------------
+launch_nukestudio:
+  defer_keyword: ''
+  engine: tk-nukestudio
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_nukestudio_256.png'
+  linux_args: --studio
+  linux_path: '@nukestudio_linux'
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@nukestudio_mac'
+  menu_name: Launch NukeStudio
+  versions: []
+  windows_args: --studio
+  windows_path: '@nukestudio_windows'
+#
+# -------------------------------------------------
+# Photoshop CC
+# -------------------------------------------------
+launch_photoshopcc:
+  defer_keyword: ''
+  engine: tk-photoshopcc
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: ''
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: '@photoshop_mac'
+  menu_name: Launch Photoshop
+  versions: []
+  windows_args: ''
+  windows_path: '@photoshop_win'
+#
+# -------------------------------------------------
+# Screening Room
+# -------------------------------------------------
+launch_screeningroom:
+  enable_rv_mode: true
+  enable_web_mode: true
+  location:
+    version: v0.3.3
+    type: app_store
+    name: tk-multi-screeningroom
+  rv_path_linux: '@rv_linux'
+  rv_path_mac: '@rv_mac'
+  rv_path_windows: '@rv_win'
+  init_hook: '{self}/init.py'
+#
+# -------------------------------------------------
+# Softimage
+# -------------------------------------------------
+launch_softimage:
+  defer_keyword: ''
+  engine: tk-softimage
+  extra: {}
+  hook_app_launch: default
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_args: ''
+  linux_path: ''
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_args: ''
+  mac_path: ''
+  menu_name: Launch Softimage
+  versions: []
+  windows_args: ''
+  windows_path: '@softimage_windows'
+#
+# -------------------------------------------------
+# rez Maya 2019
+# -------------------------------------------------
+launch_rez_maya_2019:
+  engine: tk-maya
+  extra:
+    rez_packages:
+    - maya-2019
+    # # Optional, additional rez packages
+    # - studio_maya_tools-1.2
+    # - show_maya_tools-dev
+  hook_app_launch: rez_app_launch
+  hook_before_app_launch: default
+  icon: '{target_engine}/icon_256.png'
+  linux_path: "maya"
+  location:
+    version: v0.9.15
+    type: app_store
+    name: tk-multi-launchapp
+  mac_path: "Maya.app"
+  menu_name: Rez Maya 2019
+  windows_path: "maya.exe"

--- a/tk-config-default/env/project.yml
+++ b/tk-config-default/env/project.yml
@@ -1,0 +1,590 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Apps and Engines when launching with a project only context.
+
+#################################################################################################
+# include common files
+
+includes:
+# launchers for launching DCCs such as Maya, Nuke etc.
+- ./includes/app_launchers.yml
+# common app configurations that are reused across environments
+- ./includes/common_apps.yml
+# include flame launchers
+- ./includes/flame.yml
+
+#################################################################################################
+# define all the items that should appear in this environment
+
+
+
+engines:
+  #
+  # -------------------------------------------------
+  # 3dsmax plus
+  # -------------------------------------------------
+  tk-3dsmaxplus:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 2017
+    debug_logging: false
+    location:
+      version: v0.5.1
+      type: app_store
+      name: tk-3dsmaxplus
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Shotgun Desktop
+  # -------------------------------------------------
+  tk-desktop:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflameassist: '@launch_flame_assist'
+      tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchnukestudio: '@launch_nukestudio'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+    collapse_rules:
+    - {button_label: $app, match: Launch $app, menu_label: None}
+    debug_logging: false
+    default_group: Studio
+    groups:
+    - matches: ['*Houdini*', '*Mari*', '*Max*', '*Maya*', '*Motion*', '*Nuke*', '*Photoshop*',
+        '*Softimage*']
+      name: Creative Tools
+    - matches: ['*Hiero*']
+      name: Editorial Tools
+    - matches: ['*Fla*']
+      name: Finishing Tools
+    hook_launch_python: default
+    location:
+      version: v2.4.2
+      type: app_store
+      name: tk-desktop
+    show_recents: true
+
+  #
+  # -------------------------------------------------
+  # Flame
+  # -------------------------------------------------
+  tk-flame: '@std_flame_flare'
+  #
+  # -------------------------------------------------
+  # Flare
+  # -------------------------------------------------
+  tk-flare: '@std_flame_flare'
+  #
+  # -------------------------------------------------
+  # Hiero
+  # -------------------------------------------------
+  tk-hiero:
+    apps:
+      tk-hiero-export:
+        audio_published_file_type: Hiero Audio
+        custom_template_fields: []
+        default_task_filter: '[[''step.Step.code'', ''is'', ''Comp'']]'
+        default_task_template: Basic shot template
+        hook_get_extra_publish_data: default
+        hook_get_quicktime_settings: default
+        hook_get_shot: default
+        hook_pre_export: default
+        hook_resolve_custom_strings: default
+        hook_translate_template: default
+        hook_update_version_data: default
+        hook_upload_thumbnail: default
+        location:
+          version: v0.4.3
+          type: app_store
+          name: tk-hiero-export
+        nuke_script_published_file_type: Nuke Script
+        nuke_script_toolkit_write_nodes:
+        - {channel: stereoexr32, name: 'Stereo Exr, 32 bit'}
+        - {channel: stereoexr16, name: 'Stereo Exr, 16 bit'}
+        - {channel: monodpx, name: Mono Dpx}
+        plate_published_file_type: Hiero Plate
+        template_nuke_script_path: nuke_shot_work
+        template_plate_path: hiero_plate_path
+        template_render_path: hiero_render_path
+        template_version: hiero_version
+        hook_post_version_creation: default
+      tk-hiero-openinshotgun:
+        location:
+          version: v0.3.4
+          type: app_store
+          name: tk-hiero-openinshotgun
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish Project
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the selected Hiero project
+        primary_display_name: Hiero Publish
+        primary_icon: icons/publish_hiero_main.png
+        primary_publish_template: hiero_project_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Hiero Project
+        secondary_outputs: []
+        template_work: hiero_project_work
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: hiero_project_snapshot
+        template_work: hiero_project_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Projects
+          entity_type: Project
+          filters: []
+          hierarchy: [name]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: false
+        template_publish: hiero_project_publish
+        template_publish_area: hiero_project_publish_area
+        template_work: hiero_project_work
+        template_work_area: hiero_project_work_area
+        version_compare_ignore_fields: []
+    bin_context_menu:
+    - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
+      requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot..., requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot History...,
+      requires_selection: true}
+    - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
+      requires_selection: true}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    favourite_directories: []
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    spreadsheet_context_menu:
+    - {app_instance: tk-hiero-openinshotgun, keep_in_menu: false, name: Open in Shotgun,
+      requires_selection: true}
+    timeline_context_menu:
+    - {app_instance: tk-hiero-openinshotgun, keep_in_menu: false, name: Open in Shotgun,
+      requires_selection: true}
+  #
+  # -------------------------------------------------
+  # Houdini
+  # -------------------------------------------------
+  tk-houdini:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    location:
+      version: v1.3.0
+      type: app_store
+      name: tk-houdini
+    enable_sg_shelf: true
+    debug_logging: false
+    enable_sg_menu: true
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Mari
+  # -------------------------------------------------
+  tk-mari:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-workfiles:
+        allow_task_creation: true
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        launch_change_work_area_at_startup: false
+        location:
+          version: v0.7.4
+          type: app_store
+          name: tk-multi-workfiles
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        sg_entity_type_extra_display_fields: {}
+        sg_entity_type_filters: {}
+        sg_entity_types: [Asset]
+        sg_task_filters: []
+        task_extra_display_fields: []
+        template_publish:
+        template_publish_area:
+        template_work:
+        template_work_area:
+        version_compare_ignore_fields: []
+    compatibility_dialog_min_version: 2
+    debug_logging: false
+    location:
+      version: v1.2.0
+      type: app_store
+      name: tk-mari
+  #
+  # -------------------------------------------------
+  # Maya
+  # -------------------------------------------------
+  tk-maya:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2-launch-at-startup'
+    compatibility_dialog_min_version: 2015
+    debug_logging: false
+    location:
+      version: v0.9.1
+      type: app_store
+      name: tk-maya
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Motionbuilder
+  # -------------------------------------------------
+  tk-motionbuilder:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.4.0
+      type: app_store
+      name: tk-motionbuilder
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Nuke
+  # -------------------------------------------------
+  tk-nuke:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    favourite_directories: []
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    bin_context_menu: []
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+  #
+  # -------------------------------------------------
+  # Nuke Studio
+  # -------------------------------------------------
+  tk-nukestudio:
+    apps:
+      tk-hiero-export:
+        audio_published_file_type: Hiero Audio
+        custom_template_fields: []
+        default_task_filter: '[[''step.Step.code'', ''is'', ''Comp'']]'
+        default_task_template: Basic shot template
+        hook_get_extra_publish_data: default
+        hook_get_quicktime_settings: default
+        hook_get_shot: default
+        hook_pre_export: default
+        hook_resolve_custom_strings: default
+        hook_translate_template: default
+        hook_update_version_data: default
+        hook_upload_thumbnail: default
+        location:
+          version: v0.4.3
+          type: app_store
+          name: tk-hiero-export
+        nuke_script_published_file_type: Nuke Script
+        nuke_script_toolkit_write_nodes:
+        - {channel: stereoexr32, name: 'Stereo Exr, 32 bit'}
+        - {channel: stereoexr16, name: 'Stereo Exr, 16 bit'}
+        - {channel: monodpx, name: Mono Dpx}
+        plate_published_file_type: Hiero Plate
+        template_nuke_script_path: nuke_shot_work
+        template_plate_path: hiero_plate_path
+        template_render_path: hiero_render_path
+        template_version: hiero_version
+        hook_post_version_creation: default
+      tk-hiero-openinshotgun:
+        location:
+          version: v0.3.4
+          type: app_store
+          name: tk-hiero-openinshotgun
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish Project
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the selected Hiero project
+        primary_display_name: Hiero Publish
+        primary_icon: icons/publish_hiero_main.png
+        primary_publish_template: hiero_project_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Hiero Project
+        secondary_outputs: []
+        template_work: hiero_project_work
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: hiero_project_snapshot
+        template_work: hiero_project_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Projects
+          entity_type: Project
+          filters: []
+          hierarchy: [name]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: false
+        template_publish: hiero_project_publish
+        template_publish_area: hiero_project_publish_area
+        template_work: hiero_project_work
+        template_work_area: hiero_project_work_area
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          - actions:
+            - read_node
+            filters:
+              published_file_type: Rendered Image
+          - actions:
+            - script_import
+            filters:
+              published_file_type: Nuke Script
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    bin_context_menu:
+    - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
+      requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot..., requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot History...,
+      requires_selection: true}
+    - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
+      requires_selection: true}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    favourite_directories: []
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    spreadsheet_context_menu:
+    - {app_instance: tk-hiero-openinshotgun, keep_in_menu: false, name: Open in Shotgun,
+      requires_selection: true}
+    timeline_context_menu:
+    - {app_instance: tk-hiero-openinshotgun, keep_in_menu: false, name: Open in Shotgun,
+      requires_selection: true}
+  #
+  # -------------------------------------------------
+  # Photoshop CC
+  # -------------------------------------------------
+  tk-photoshopcc:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    shelf_favorites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    debug_logging: false
+    location:
+      version: v1.2.1
+      type: app_store
+      name: tk-photoshopcc
+  #
+  # -------------------------------------------------
+  # Shell Engine (tank command)
+  # -------------------------------------------------
+  tk-shell:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchnukestudio: '@launch_nukestudio'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflameassist: '@launch_flame_assist'
+    location:
+      version: v0.6.0
+      type: app_store
+      name: tk-shell
+  #
+  # -------------------------------------------------
+  # Softimage
+  # -------------------------------------------------
+  tk-softimage:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.3.4
+      type: app_store
+      name: tk-softimage
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks:
+  tk-framework-adminui_v0.x.x:
+    location:
+      version: v0.2.1
+      type: app_store
+      name: tk-framework-adminui
+  tk-framework-softimageqt_v1.0.1:
+    location:
+      name: tk-framework-softimageqt
+      type: app_store
+      version: v1.0.1
+  tk-framework-desktopserver_v1.x.x:
+    location:
+      version: v1.3.1
+      type: app_store
+      name: tk-framework-desktopserver

--- a/tk-config-default/env/sequence.yml
+++ b/tk-config-default/env/sequence.yml
@@ -1,0 +1,186 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Apps and engines loaded when a Sequence is loaded. Since std VFX config
+  template has a file system structure which is centered around pipeline steps, this
+  environment is largely empty. Most of the work takes place on a level in the file
+  system where both a shot and a pipeline step is available - e.g Shot ABC, modeling,
+  so all apps for loading, publishing etc. are located in the shot_step environment.
+  This environment mostly contains utility apps and the tank work files app, which
+  lets you choose a task to work on and load associated content into an application.
+
+
+#################################################################################################
+# include common files
+
+includes:
+# launchers for launching DCCs such as Maya, Nuke etc.
+- ./includes/app_launchers.yml
+# common app configurations that are reused across environments
+- ./includes/common_apps.yml
+
+
+#################################################################################################
+# define all the items that should appear in this environment
+
+engines:
+  #
+  # -------------------------------------------------
+  # 3dsmax plus
+  # -------------------------------------------------
+  tk-3dsmaxplus:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 2017
+    debug_logging: false
+    location:
+      version: v0.5.1
+      type: app_store
+      name: tk-3dsmaxplus
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Houdini
+  # -------------------------------------------------
+  tk-houdini:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    location:
+      version: v1.3.0
+      type: app_store
+      name: tk-houdini
+    enable_sg_shelf: true
+    debug_logging: false
+    enable_sg_menu: true
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Maya
+  # -------------------------------------------------
+  tk-maya:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2-launch-at-startup'
+    compatibility_dialog_min_version: 2015
+    debug_logging: false
+    location:
+      version: v0.9.1
+      type: app_store
+      name: tk-maya
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Motionbuilder
+  # -------------------------------------------------
+  tk-motionbuilder:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.4.0
+      type: app_store
+      name: tk-motionbuilder
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Nuke
+  # -------------------------------------------------
+  tk-nuke:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    favourite_directories: []
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    bin_context_menu: []
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Shell (tank command)
+  # -------------------------------------------------
+  tk-shell:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+    location:
+      version: v0.6.0
+      type: app_store
+      name: tk-shell
+  #
+  # -------------------------------------------------
+  # Softimage
+  # -------------------------------------------------
+  tk-softimage:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.3.4
+      type: app_store
+      name: tk-softimage
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks:
+  tk-framework-softimageqt_v1.0.1:
+    location:
+      name: tk-framework-softimageqt
+      type: app_store
+      version: v1.0.1

--- a/tk-config-default/env/shot.yml
+++ b/tk-config-default/env/shot.yml
@@ -1,0 +1,216 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Apps and engines loaded when a Shot is loaded. Since std VFX config template
+  has a file system structure which is centered around pipeline steps, this environment
+  is largely empty. Most of the work takes place on a level in the file system where
+  both a shot and a pipeline step is available - e.g Shot ABC, modeling, so all apps
+  for loading, publishing etc. are located in the shot_step environment. This environment
+  mostly contains utility apps and the tank work files app, which lets you choose
+  a task to work on and load associated content into an application.
+
+#################################################################################################
+# include common files
+
+includes:
+# launchers for launching DCCs such as Maya, Nuke etc.
+- ./includes/app_launchers.yml
+# common app configurations that are reused across environments
+- ./includes/common_apps.yml
+# include flame launchers
+- ./includes/flame.yml
+
+#################################################################################################
+# define all the items that should appear in this environment
+
+
+engines:
+  #
+  # -------------------------------------------------
+  # 3dsmax plus
+  # -------------------------------------------------
+  tk-3dsmaxplus:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 2017
+    debug_logging: false
+    location:
+      version: v0.5.1
+      type: app_store
+      name: tk-3dsmaxplus
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # Houdini
+  # -------------------------------------------------
+  tk-houdini:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    location:
+      version: v1.3.0
+      type: app_store
+      name: tk-houdini
+    enable_sg_shelf: true
+    debug_logging: false
+    enable_sg_menu: true
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # maya
+  # -------------------------------------------------
+  tk-maya:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2-launch-at-startup'
+    compatibility_dialog_min_version: 2015
+    debug_logging: false
+    location:
+      version: v0.9.1
+      type: app_store
+      name: tk-maya
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # motionbuilder
+  # -------------------------------------------------
+  tk-motionbuilder:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.4.0
+      type: app_store
+      name: tk-motionbuilder
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # nuke
+  # -------------------------------------------------
+  tk-nuke:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    favourite_directories: []
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    bin_context_menu: []
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+  #
+  # -------------------------------------------------
+  # Photoshop CC
+  # -------------------------------------------------
+  tk-photoshopcc:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    shelf_favorites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    debug_logging: false
+    location:
+      version: v1.2.1
+      type: app_store
+      name: tk-photoshopcc
+  #
+  # -------------------------------------------------
+  # Flame
+  # -------------------------------------------------
+  tk-flame: '@std_flame_flare'
+  #
+  # -------------------------------------------------
+  # Flare
+  # -------------------------------------------------
+  tk-flare: '@std_flame_flare'
+  #
+  # -------------------------------------------------
+  # Shell (tank command)
+  # -------------------------------------------------
+  tk-shell:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+    location:
+      version: v0.6.0
+      type: app_store
+      name: tk-shell
+  #
+  # -------------------------------------------------
+  # Softimage
+  # -------------------------------------------------
+  tk-softimage:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-shotgunpanel: '@shotgunpanel'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-workfiles2: '@workfiles2'
+    debug_logging: false
+    location:
+      version: v0.3.4
+      type: app_store
+      name: tk-softimage
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    template_project:
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks:
+  tk-framework-softimageqt_v1.0.1:
+    location:
+      name: tk-framework-softimageqt
+      type: app_store
+      version: v1.0.1

--- a/tk-config-default/env/shot_step.yml
+++ b/tk-config-default/env/shot_step.yml
@@ -1,0 +1,1444 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: Apps and Engines related to Shot based work.
+
+#################################################################################################
+# include common files
+
+includes:
+# launchers for launching DCCs such as Maya, Nuke etc.
+- ./includes/app_launchers.yml
+# common app configurations that are reused across environments
+- ./includes/common_apps.yml
+
+#################################################################################################
+# define all the items that should appear in this environment
+
+engines:
+  #
+  # -------------------------------------------------
+  # 3dsmax plus
+  # -------------------------------------------------
+  tk-3dsmaxplus:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-loader2:
+        action_mappings:
+          3dsmax Scene: [import, reference]
+          Alembic Cache: [import]
+        actions_hook: '{self}/tk-3dsmaxplus_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+          publish_filters: []
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+          publish_filters: []
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+          publish_filters: []
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current 3ds Max scene
+        primary_display_name: 3ds Max Publish
+        primary_icon: icons/publish_3dsmax_main.png
+        primary_publish_template: max_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: 3dsmax Scene
+        secondary_outputs: []
+        template_work: max_shot_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-multi-setframerange
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: max_shot_snapshot
+        template_work: max_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: max_shot_publish
+        template_publish_area: shot_publish_area_max
+        template_work: max_shot_work
+        template_work_area: shot_work_area_max
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    compatibility_dialog_min_version: 2017
+    debug_logging: false
+    location:
+      version: v0.5.1
+      type: app_store
+      name: tk-3dsmaxplus
+    menu_favourites: []
+  #
+  # -------------------------------------------------
+  # houdini
+  # -------------------------------------------------
+  tk-houdini:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current scene
+        primary_display_name: Scene File Publish
+        primary_icon: icons/publish_houdini_main.png
+        primary_publish_template: houdini_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Houdini Scene
+        secondary_outputs:
+        - description: Publish Alembic Cache data for the model
+          display_group: Caches
+          display_name: Alembic Cache
+          group_name: Alembic Caches
+          icon: icons/alembic_cache_publish.png
+          name: alembic_cache
+          publish_group: true
+          publish_template: houdini_shot_work_alembic_cache
+          required: false
+          scene_item_type: alembic_cache
+          selected: false
+          tank_type: Alembic Cache
+        - description: Publish a rendered image sequence
+          display_group: Renders
+          display_name: Rendered
+          group_name: default
+          icon: icons/publish_houdini_renders.png
+          name: rendered_image
+          publish_group: false
+          publish_template: houdini_shot_render
+          required: false
+          scene_item_type: rendered_image
+          selected: false
+          tank_type: Rendered Image
+        template_work: houdini_shot_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-multi-setframerange
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: houdini_shot_snapshot
+        template_work: houdini_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: houdini_shot_publish
+        template_publish_area: shot_publish_area_houdini
+        template_work: houdini_shot_work
+        template_work_area: shot_work_area_houdini
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+        actions_hook: '{self}/general_actions.py'
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+      tk-houdini-alembicnode:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-houdini-alembicnode
+        work_file_template: houdini_shot_work
+        default_node_name: sg_alembic_out
+        output_profiles:
+        - name: Shot Work Cache
+          settings: {}
+          color: []
+          output_cache_template: houdini_shot_work_alembic_cache
+      tk-houdini-mantranode:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-houdini-mantranode
+        work_file_template: houdini_shot_work
+        default_node_name: sg_mantra_out
+        output_profiles:
+        - name: Default Render
+          settings: {}
+          color: []
+          output_render_template: houdini_shot_render
+          output_ifd_template: houdini_shot_ifd
+          output_dcm_template: houdini_shot_dcm
+          output_extra_plane_template: houdini_shot_extra_plane
+      tk-multi-loader2:
+        action_mappings:
+          Alembic Cache: [import]
+        actions_hook: '{self}/tk-houdini_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-houdini_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+    debug_logging: false
+    enable_sg_shelf: true
+    enable_sg_menu: true
+    location:
+      version: v1.3.0
+      type: app_store
+      name: tk-houdini
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+  #
+  # -------------------------------------------------
+  # maya
+  # -------------------------------------------------
+  tk-maya:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-maya_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Maya Scene: [reference, import]
+          Photoshop Image: [texture_node]
+          Rendered Image: [texture_node]
+        actions_hook: '{self}/tk-maya_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current Maya scene
+        primary_display_name: Maya Publish
+        primary_icon: icons/publish_maya_main.png
+        primary_publish_template: maya_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Maya Scene
+        secondary_outputs: []
+        template_work: maya_shot_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-multi-setframerange
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [reference, import]
+            filters: {published_file_type: Maya Scene}
+          - actions: [texture_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [texture_node]
+            filters: {published_file_type: Photoshop Image}
+          - actions: [udim_texture_node]
+            filters: {published_file_type: UDIM Image}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-maya_actions.py'
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: maya_shot_snapshot
+        template_work: maya_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: maya_shot_publish
+        template_publish_area: shot_publish_area_maya
+        template_work: maya_shot_work
+        template_work_area: shot_work_area_maya
+        version_compare_ignore_fields: []
+    compatibility_dialog_min_version: 2015
+    debug_logging: false
+    location:
+      version: v0.9.1
+      type: app_store
+      name: tk-maya
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    template_project: shot_work_area_maya
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # motionbuilder
+  # -------------------------------------------------
+  tk-motionbuilder:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-loader2:
+        action_mappings:
+          Motion Builder FBX: [import]
+        actions_hook: '{self}/tk-motionbuilder_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current work file
+        primary_display_name: Current Work File
+        primary_icon: icons/publish_motionbuilder_main.png
+        primary_publish_template: mobu_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Motion Builder FBX
+        secondary_outputs: []
+        template_work: mobu_shot_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-multi-setframerange
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: mobu_shot_snapshot
+        template_work: mobu_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: mobu_shot_publish
+        template_publish_area: shot_publish_area_mobu
+        template_work: mobu_shot_work
+        template_work_area: shot_work_area_mobu
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    debug_logging: false
+    location:
+      version: v0.4.0
+      type: app_store
+      name: tk-motionbuilder
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Nuke
+  # -------------------------------------------------
+  tk-nuke:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Nuke Script: [script_import]
+          Rendered Image: [read_node]
+          Alembic Cache: [read_node]
+          Flame Render: [read_node]
+          Flame Quicktime: [read_node]
+        actions_hook: '{self}/tk-nuke_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publishes and versions up the current Nuke script.
+        primary_display_name: Nuke Publish
+        primary_icon: icons/publish_nuke_main.png
+        primary_publish_template: nuke_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Nuke Script
+        secondary_outputs:
+        - description: Copy renders from work area to publish area.
+          display_group: Shotgun Write Nodes
+          display_name: Publish Renders
+          icon: icons/publish_nuke_writenode.png
+          name: render
+          publish_template:
+          required: false
+          scene_item_type: write_node
+          selected: true
+          tank_type: Rendered Image
+        - description: Create quicktime and send to Screening Room
+          display_group: Shotgun Write Nodes
+          display_name: Send to Screening Room
+          icon: icons/publish_nuke_review.png
+          name: quicktime
+          publish_template:
+          required: false
+          scene_item_type: write_node
+          selected: true
+          tank_type: Quicktime
+        - description: Make this publish available in Flame
+          display_group: Shotgun Write Nodes
+          display_name: Update Flame
+          icon: icons/publish_nuke_flame.png
+          name: flame
+          publish_template: flame_shot_clip
+          required: false
+          scene_item_type: write_node
+          selected: true
+          tank_type: unused
+        template_work: nuke_shot_work
+      tk-multi-reviewsubmission:
+        location:
+          version: v0.3.2
+          type: app_store
+          name: tk-multi-reviewsubmission
+        movie_height: 540
+        movie_path_template: nuke_shot_render_movie
+        movie_width: 1024
+        new_version_status: rev
+        slate_logo: icons/review_submit_logo.png
+        store_on_disk: true
+        upload_to_shotgun: true
+        version_number_padding: 3
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          name: tk-multi-setframerange
+          type: app_store
+          version: v0.3.0
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [read_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [script_import]
+            filters: {published_file_type: Nuke Script}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: nuke_shot_snapshot
+        template_work: nuke_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: nuke_shot_publish
+        template_publish_area: shot_publish_area_nuke
+        template_work: nuke_shot_work
+        template_work_area: shot_work_area_nuke
+        version_compare_ignore_fields: []
+      tk-nuke-quickdailies:
+        current_scene_template: nuke_shot_work
+        height: 768
+        location:
+          version: v0.3.6
+          type: app_store
+          name: tk-nuke-quickdailies
+        movie_template: shot_quicktime_quick
+        post_hooks: [snapshot_history_post_quickdaily]
+        sg_version_name_template: nuke_quick_shot_version_name
+        width: 1024
+        upload_movie: true
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-nuke-writenode:
+        location:
+          version: v1.2.0
+          type: app_store
+          name: tk-nuke-writenode
+        template_script_work: nuke_shot_work
+        write_nodes:
+        - file_type: exr
+          name: Stereo Exr, 32 bit
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_stereo
+          render_template: nuke_shot_render_stereo
+          settings:
+            datatype: 32 bit float
+          tank_type: Rendered Image
+          tile_color: []
+          promote_write_knobs: []
+        - file_type: exr
+          name: Stereo Exr, 16 bit
+          promote_write_knobs: []
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_stereo
+          render_template: nuke_shot_render_stereo
+          settings:
+            datatype: 16 bit half
+          tank_type: Rendered Image
+          tile_color: []
+        - file_type: dpx
+          name: Mono Dpx
+          promote_write_knobs: []
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_mono_dpx
+          render_template: nuke_shot_render_mono_dpx
+          settings: {}
+          tank_type: Rendered Image
+          tile_color: []
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    favourite_directories: []
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    bin_context_menu: []
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+
+  #
+  # -------------------------------------------------
+  # Nuke Studio
+  # -------------------------------------------------
+  tk-nukestudio:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish Project
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the selected Hiero project
+        primary_display_name: Hiero Publish
+        primary_icon: icons/publish_hiero_main.png
+        primary_publish_template: hiero_project_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Hiero Project
+        secondary_outputs: []
+        template_work: hiero_project_work
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: hiero_project_snapshot
+        template_work: hiero_project_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Projects
+          entity_type: Project
+          filters: []
+          hierarchy: [name]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: false
+        template_publish: hiero_project_publish
+        template_publish_area: hiero_project_publish_area
+        template_work: hiero_project_work
+        template_work_area: hiero_project_work_area
+        version_compare_ignore_fields: []
+      tk-nuke-quickdailies:
+        current_scene_template: nuke_shot_work
+        height: 768
+        location:
+          version: v0.3.6
+          type: app_store
+          name: tk-nuke-quickdailies
+        movie_template: shot_quicktime_quick
+        post_hooks: [snapshot_history_post_quickdaily]
+        sg_version_name_template: nuke_quick_shot_version_name
+        width: 1024
+        upload_movie: true
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-nuke-writenode:
+        location:
+          version: v1.2.0
+          type: app_store
+          name: tk-nuke-writenode
+        template_script_work: nuke_shot_work
+        write_nodes:
+        - file_type: exr
+          name: Stereo Exr, 32 bit
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_stereo
+          render_template: nuke_shot_render_stereo
+          settings:
+            datatype: 32 bit float
+          tank_type: Rendered Image
+          tile_color: []
+          promote_write_knobs: []
+        - file_type: exr
+          name: Stereo Exr, 16 bit
+          promote_write_knobs: []
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_stereo
+          render_template: nuke_shot_render_stereo
+          settings:
+            datatype: 16 bit half
+          tank_type: Rendered Image
+          tile_color: []
+        - file_type: dpx
+          name: Mono Dpx
+          promote_write_knobs: []
+          proxy_publish_template:
+          proxy_render_template:
+          publish_template: nuke_shot_render_pub_mono_dpx
+          render_template: nuke_shot_render_mono_dpx
+          settings: {}
+          tank_type: Rendered Image
+          tile_color: []
+      tk-multi-reviewsubmission:
+        location:
+          version: v0.3.2
+          type: app_store
+          name: tk-multi-reviewsubmission
+        movie_height: 540
+        movie_path_template: nuke_shot_render_movie
+        movie_width: 1024
+        new_version_status: rev
+        slate_logo: icons/review_submit_logo.png
+        store_on_disk: true
+        upload_to_shotgun: true
+        version_number_padding: 3
+        codec_settings_hook: '{self}/codec_settings.py'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          name: tk-multi-setframerange
+          type: app_store
+          version: v0.3.0
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-breakdown:
+        hook_scene_operations: '{self}/tk-nuke_scene_operations.py'
+        location:
+          version: v1.4.6
+          type: app_store
+          name: tk-multi-breakdown
+      tk-multi-loader2:
+        action_mappings:
+          Nuke Script: [script_import]
+          Rendered Image: [read_node]
+          Alembic Cache: [read_node]
+        actions_hook: '{self}/tk-nuke_actions.py'
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-shotgunpanel:
+        action_mappings:
+          PublishedFile:
+          - actions: [read_node]
+            filters: {published_file_type: Rendered Image}
+          - actions: [script_import]
+            filters: {published_file_type: Nuke Script}
+          Task:
+          - actions: [assign_task, task_to_ip]
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+        actions_hook: '{self}/general_actions.py:{self}/tk-nuke_actions.py'
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+    bin_context_menu:
+    - {app_instance: tk-multi-workfiles2, keep_in_menu: false, name: File Save...,
+      requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot..., requires_selection: true}
+    - {app_instance: tk-multi-snapshot, keep_in_menu: false, name: Snapshot History...,
+      requires_selection: true}
+    - {app_instance: tk-multi-publish, keep_in_menu: false, name: Publish Project...,
+      requires_selection: true}
+    project_favourite_name: Shotgun Current Project
+    use_sgtk_as_menu_name: false
+    favourite_directories: []
+    compatibility_dialog_min_version: 10
+    debug_logging: false
+    location:
+      version: v0.9.4
+      type: app_store
+      name: tk-nuke
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    spreadsheet_context_menu: []
+    timeline_context_menu: []
+  #
+  # -------------------------------------------------
+  # Photoshop CC
+  # -------------------------------------------------
+  tk-photoshopcc:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-loader2:
+        action_mappings:
+          Photoshop Image: [add_as_a_layer, open_file]
+          Rendered Image: [add_as_a_layer, open_file]
+        actions_hook: default
+        download_thumbnails: true
+        entities:
+        - caption: Assets
+          entity_type: Asset
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_asset_type, code]
+        - caption: Shots
+          entity_type: Shot
+          filters:
+          - [project, is, '{context.project}']
+          hierarchy: [sg_sequence, code]
+        - caption: My Tasks
+          entity_type: Task
+          filters:
+          - [task_assignees, is, '{context.user}']
+          - [project, is, '{context.project}']
+          hierarchy: [entity, content]
+        filter_publishes_hook: '{self}/filter_publishes.py'
+        location:
+          version: v1.18.1
+          type: app_store
+          name: tk-multi-loader2
+        menu_name: Load
+        publish_filters: []
+        title_name: Loader
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current Photoshop scene
+        primary_display_name: Photoshop Publish
+        primary_icon: icons/publish_photoshop_main.png
+        primary_publish_template: photoshop_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Photoshop Image
+        secondary_outputs: []
+        template_work: photoshop_shot_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: photoshop_shot_snapshot
+        template_work: photoshop_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: photoshop_shot_publish
+        template_publish_area: shot_publish_area_photoshop
+        template_work: photoshop_shot_work
+        template_work_area: shot_work_area_photoshop
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    shelf_favorites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    debug_logging: false
+    location:
+      version: v1.2.1
+      type: app_store
+      name: tk-photoshopcc
+  #
+  # -------------------------------------------------
+  # Shell (tank command)
+  # -------------------------------------------------
+  tk-shell:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+    location:
+      version: v0.6.0
+      type: app_store
+      name: tk-shell
+  #
+  # -------------------------------------------------
+  # Softimage
+  # -------------------------------------------------
+  tk-softimage:
+    apps:
+      tk-multi-about: '@about'
+      tk-multi-publish:
+        allow_taskless_publishes: true
+        display_name: Publish
+        expand_single_items: false
+        hook_copy_file: default
+        hook_post_publish: default
+        hook_primary_pre_publish: default
+        hook_primary_publish: default
+        hook_scan_scene: default
+        hook_secondary_pre_publish: default
+        hook_secondary_publish: default
+        hook_thumbnail: default
+        location:
+          version: v0.10.9
+          type: app_store
+          name: tk-multi-publish
+        primary_description: Publish and version up the current Softimage scene
+        primary_display_name: Softimage Publish
+        primary_icon: icons/publish_softimage_main.png
+        primary_publish_template: softimage_shot_publish
+        primary_scene_item_type: work_file
+        primary_tank_type: Softimage Scene
+        secondary_outputs: []
+        template_work: softimage_shot_work
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-multi-setframerange:
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-multi-setframerange
+        sg_in_frame_field: sg_cut_in
+        sg_out_frame_field: sg_cut_out
+      tk-multi-snapshot:
+        hook_copy_file: default
+        hook_scene_operation: default
+        hook_thumbnail: default
+        location:
+          version: v0.7.3
+          type: app_store
+          name: tk-multi-snapshot
+        template_snapshot: softimage_shot_snapshot
+        template_work: softimage_shot_work
+      tk-multi-workfiles2:
+        allow_task_creation: true
+        create_new_task_hook: default
+        custom_actions_hook: default
+        entities:
+        - caption: Assets
+          entity_type: Task
+          filters:
+          - [entity, type_is, Asset]
+          hierarchy: [entity.Asset.sg_asset_type, entity, step, content]
+        - caption: Shots
+          entity_type: Task
+          filters:
+          - [entity, type_is, Shot]
+          hierarchy: [entity.Shot.sg_sequence, entity, step, content]
+        file_extensions: []
+        hook_copy_file: default
+        hook_filter_publishes: default
+        hook_filter_work_files: default
+        hook_scene_operation: default
+        launch_at_startup: false
+        location:
+          version: v0.9.9
+          type: app_store
+          name: tk-multi-workfiles2
+        my_tasks_extra_display_fields: []
+        saveas_default_name: scene
+        saveas_prefer_version_up: false
+        show_my_tasks: true
+        template_publish: softimage_shot_publish
+        template_publish_area: shot_publish_area_softimage
+        template_work: softimage_shot_work
+        template_work_area: shot_work_area_softimage
+        version_compare_ignore_fields: []
+      tk-multi-shotgunpanel:
+        location:
+          version: v1.4.9
+          type: app_store
+          name: tk-multi-shotgunpanel
+        shotgun_fields_hook: '{self}/shotgun_fields.py'
+        actions_hook: '{self}/general_actions.py'
+        action_mappings:
+          PublishedFile:
+          - actions:
+            - publish_clipboard
+            filters: {}
+          Task:
+          - actions:
+            - assign_task
+            - task_to_ip
+            filters: {}
+          Version:
+          - actions:
+            - quicktime_clipboard
+            - sequence_clipboard
+            filters: {}
+    debug_logging: false
+    location:
+      version: v0.3.4
+      type: app_store
+      name: tk-softimage
+    menu_favourites:
+    - {app_instance: tk-multi-workfiles2, name: File Open...}
+    - {app_instance: tk-multi-snapshot, name: Snapshot...}
+    - {app_instance: tk-multi-workfiles2, name: File Save...}
+    - {app_instance: tk-multi-publish, name: Publish...}
+    template_project: shot_work_area_softimage
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks:
+  tk-framework-softimageqt_v1.0.1:
+    location:
+      name: tk-framework-softimageqt
+      type: app_store
+      version: v1.0.1

--- a/tk-config-default/env/shotgun_asset.yml
+++ b/tk-config-default/env/shotgun_asset.yml
@@ -1,0 +1,70 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+  for assets.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-folders:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          version: v0.1.6
+          type: app_store
+          name: tk-shotgun-folders
+      tk-shotgun-launchfolder:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          name: tk-shotgun-launchfolder
+          type: app_store
+          version: v0.1.5
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_project.yml
+++ b/tk-config-default/env/shotgun_project.yml
@@ -1,0 +1,69 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+  for projects.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflameassist: '@launch_flame_assist'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchnukestudio: '@launch_nukestudio'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-launchfolder:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          name: tk-shotgun-launchfolder
+          type: app_store
+          version: v0.1.5
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_publishedfile.yml
+++ b/tk-config-default/env/shotgun_publishedfile.yml
@@ -1,0 +1,69 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+  for publishes.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-launchpublish:
+        deny_permissions: []
+        deny_platforms: []
+        hook_launch_publish: default
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-shotgun-launchpublish
+        viewer_extensions: [exr, dpx, cin]
+        viewer_path_linux: '@rv_linux'
+        viewer_path_mac: '@rv_mac'
+        viewer_path_windows: '@rv_win'
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_sequence.yml
+++ b/tk-config-default/env/shotgun_sequence.yml
@@ -1,0 +1,70 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+             for shots.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-folders:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          version: v0.1.6
+          type: app_store
+          name: tk-shotgun-folders
+      tk-shotgun-launchfolder:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          name: tk-shotgun-launchfolder
+          type: app_store
+          version: v0.1.5
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_shot.yml
+++ b/tk-config-default/env/shotgun_shot.yml
@@ -1,0 +1,72 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+             for shots.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchflare: '@launch_flare'
+      tk-multi-launchflame: '@launch_flame'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-folders:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          version: v0.1.6
+          type: app_store
+          name: tk-shotgun-folders
+      tk-shotgun-launchfolder:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          name: tk-shotgun-launchfolder
+          type: app_store
+          version: v0.1.5
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_tankpublishedfile.yml
+++ b/tk-config-default/env/shotgun_tankpublishedfile.yml
@@ -1,0 +1,70 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+             for publishes.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-launchpublish:
+        deny_permissions: []
+        deny_platforms: []
+        hook_launch_publish: default
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-shotgun-launchpublish
+        viewer_extensions: [exr, dpx, cin]
+        viewer_path_linux: '@rv_linux'
+        viewer_path_mac: '@rv_mac'
+        viewer_path_windows: '@rv_win'
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_task.yml
+++ b/tk-config-default/env/shotgun_task.yml
@@ -1,0 +1,64 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+             for tasks.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmari: '@launch_mari'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-launchfolder:
+        deny_permissions: []
+        deny_platforms: []
+        location:
+          name: tk-shotgun-launchfolder
+          type: app_store
+          version: v0.1.5
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/env/shotgun_version.yml
+++ b/tk-config-default/env/shotgun_version.yml
@@ -1,0 +1,69 @@
+# Copyright (c) 2015 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+description: This environment controls what items should be shown on the menu in Shotgun
+             for publishes.
+
+#################################################################################################
+# include common definitions for all the launchers that are used to start maya, nuke etc.
+
+includes:
+- ./includes/app_launchers.yml
+- ./includes/paths.yml
+
+#################################################################################################
+# Define all the items that should appear in this environment
+#
+# Note! This environment is special and is only used by the Shotgun action
+# menu integration. It can only contain a Shotgun engine and the file name
+# reflects the entity type for which a menu will be generated in Shotgun.
+#
+
+engines:
+  tk-shotgun:
+    apps:
+      tk-multi-launch3dsmax: '@launch_3dsmax'
+      tk-multi-launchhiero: '@launch_hiero'
+      tk-multi-launchhoudini: '@launch_houdini'
+      tk-multi-launchmaya: '@launch_maya'
+      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+      tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+      tk-multi-launchnuke: '@launch_nuke'
+      tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+      tk-multi-launchsoftimage: '@launch_softimage'
+      tk-multi-screeningroom: '@launch_screeningroom'
+      tk-shotgun-launchpublish:
+        deny_permissions: []
+        deny_platforms: []
+        hook_launch_publish: default
+        location:
+          version: v0.3.0
+          type: app_store
+          name: tk-shotgun-launchpublish
+        viewer_extensions: [exr, dpx, cin]
+        viewer_path_linux: '@rv_linux'
+        viewer_path_mac: '@rv_mac'
+        viewer_path_windows: '@rv_win'
+    debug_logging: false
+    location:
+      version: v0.7.0
+      type: app_store
+      name: tk-shotgun
+#
+###############################################################################
+#
+# Framework includes.
+#
+# Frameworks are libraries that are shared between apps and that contain
+# common functionality for building UIs and communicating with Shotgun.
+# Frameworks are automatically installed when apps are installed and udpated.
+#
+frameworks: null

--- a/tk-config-default/example-configs.patch
+++ b/tk-config-default/example-configs.patch
@@ -1,0 +1,204 @@
+Index: env/shotgun_version.yml
+===================================================================
+--- env/shotgun_version.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_version.yml	(date 1576093040371)
+@@ -34,6 +34,7 @@
+       tk-multi-launchhiero: '@launch_hiero'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/shot_step.yml
+===================================================================
+--- env/shot_step.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shot_step.yml	(date 1576093040369)
+@@ -1301,6 +1301,7 @@
+       tk-multi-launch3dsmax: '@launch_3dsmax'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/shotgun_publishedfile.yml
+===================================================================
+--- env/shotgun_publishedfile.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_publishedfile.yml	(date 1576093040368)
+@@ -34,6 +34,7 @@
+       tk-multi-launchhiero: '@launch_hiero'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/sequence.yml
+===================================================================
+--- env/sequence.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/sequence.yml	(date 1576093040371)
+@@ -141,6 +141,7 @@
+       tk-multi-launch3dsmax: '@launch_3dsmax'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/asset_step.yml
+===================================================================
+--- env/asset_step.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/asset_step.yml	(date 1576093040371)
+@@ -1396,6 +1396,7 @@
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmari: '@launch_mari'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/shot.yml
+===================================================================
+--- env/shot.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shot.yml	(date 1576093040371)
+@@ -169,6 +169,7 @@
+       tk-multi-launch3dsmax: '@launch_3dsmax'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchflare: '@launch_flare'
+Index: env/project.yml
+===================================================================
+--- env/project.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/project.yml	(date 1576093040367)
+@@ -59,6 +59,7 @@
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmari: '@launch_mari'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchnukestudio: '@launch_nukestudio'
+@@ -530,6 +531,7 @@
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmari: '@launch_mari'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchnukestudio: '@launch_nukestudio'
+Index: env/includes/app_launchers.yml
+===================================================================
+--- env/includes/app_launchers.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/includes/app_launchers.yml	(date 1576092678162)
+@@ -338,3 +338,23 @@
+   versions: []
+   windows_args: ''
+   windows_path: '@softimage_windows'
++#
++# -------------------------------------------------
++# rez Maya 2019
++# -------------------------------------------------
++launch_rez_maya_2019:
++  engine: tk-maya
++  extra:
++    rez_packages:
++    - maya-2019
++  hook_app_launch: rez_app_launch
++  hook_before_app_launch: default
++  icon: '{target_engine}/icon_256.png'
++  linux_path: "maya"
++  location:
++    version: v0.9.15
++    type: app_store
++    name: tk-multi-launchapp
++  mac_path: "Maya.app"
++  menu_name: Rez Maya 2019
++  windows_path: "maya.exe"
+Index: env/shotgun_tankpublishedfile.yml
+===================================================================
+--- env/shotgun_tankpublishedfile.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_tankpublishedfile.yml	(date 1576093040368)
+@@ -35,6 +35,7 @@
+       tk-multi-launchhiero: '@launch_hiero'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/shotgun_asset.yml
+===================================================================
+--- env/shotgun_asset.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_asset.yml	(date 1576093040370)
+@@ -33,6 +33,7 @@
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmari: '@launch_mari'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/shotgun_project.yml
+===================================================================
+--- env/shotgun_project.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_project.yml	(date 1576093040370)
+@@ -38,6 +38,7 @@
+       tk-multi-launchflare: '@launch_flare'
+       tk-multi-launchflameassist: '@launch_flame_assist'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchnukestudio: '@launch_nukestudio'
+Index: env/shotgun_shot.yml
+===================================================================
+--- env/shotgun_shot.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_shot.yml	(date 1576093040367)
+@@ -33,6 +33,7 @@
+       tk-multi-launch3dsmax: '@launch_3dsmax'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchflare: '@launch_flare'
+Index: env/shotgun_task.yml
+===================================================================
+--- env/shotgun_task.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_task.yml	(date 1576093040368)
+@@ -34,6 +34,7 @@
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmari: '@launch_mari'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/asset.yml
+===================================================================
+--- env/asset.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/asset.yml	(date 1576093040367)
+@@ -196,6 +196,7 @@
+       tk-multi-launch3dsmax: '@launch_3dsmax'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'
+Index: env/shotgun_sequence.yml
+===================================================================
+--- env/shotgun_sequence.yml	(revision e3a5455d90c7e0c5c576a720a4bd689ee4cbf776)
++++ env/shotgun_sequence.yml	(date 1576093040372)
+@@ -33,6 +33,7 @@
+       tk-multi-launch3dsmax: '@launch_3dsmax'
+       tk-multi-launchhoudini: '@launch_houdini'
+       tk-multi-launchmaya: '@launch_maya'
++      tk-multi-launchrez_maya_2019: '@launch_rez_maya_2019'  # Added this for rez Maya 2019!
+       tk-multi-launchmotionbuilder: '@launch_motionbuilder'
+       tk-multi-launchnuke: '@launch_nuke'
+       tk-multi-launchphotoshopcc: '@launch_photoshopcc'

--- a/tk-config-default/hooks/rez_app_launch.py
+++ b/tk-config-default/hooks/rez_app_launch.py
@@ -1,0 +1,150 @@
+"""tk-config-default hook to run applications, potentially in a Rez context.
+
+Please note that this requires Rez to be installed as a package,
+which exposes the Rez Python API. With a proper Rez installation, you can do
+this by running ``rez-bind rez``.
+"""
+from __future__ import print_function
+
+import os
+import sys
+import subprocess
+import tank
+
+
+class AppLaunch(tank.Hook):
+    """
+    Hook to run an application.
+    """
+
+    def execute(self, app_path, app_args, version, **kwargs):
+        """
+        The execute functon of the hook will be called to start the required application
+
+        :param app_path: (str) The path of the application executable
+        :param app_args: (str) Any arguments the application may require
+        :param version: (str) version of the application being run if set in the "versions" settings
+                              of the Launcher instance, otherwise None
+
+        :returns: (dict) The two valid keys are 'command' (str) and 'return_code' (int).
+        """
+
+        multi_launchapp = self.parent
+        extra = multi_launchapp.get_setting("extra")
+
+        use_rez = False
+        if self.check_rez():
+            from rez.resolved_context import ResolvedContext
+            from rez.config import config
+
+            # Define variables used to bootstrap tank from overwrite on first reference
+            # PYTHONPATH is used by tk-maya
+            # NUKE_PATH is used by tk-nuke
+            # HIERO_PLUGIN_PATH is used by tk-nuke (nukestudio)
+            # KATANA_RESOURCES is used by tk-katana
+            config.parent_variables = ["PYTHONPATH", "HOUDINI_PATH", "NUKE_PATH", "HIERO_PLUGIN_PATH", "KATANA_RESOURCES"]
+
+            rez_packages = extra["rez_packages"]
+            context = ResolvedContext(rez_packages)
+
+            use_rez = True
+
+        system = sys.platform
+        shell_type = 'bash'
+        if system == "linux2":
+            # on linux, we just run the executable directly
+            cmd = "%s %s &" % (app_path, app_args)
+
+        elif self.parent.get_setting("engine") in ["tk-flame", "tk-flare"]:
+            # flame and flare works in a different way from other DCCs
+            # on both linux and mac, they run unix-style command line
+            # and on the mac the more standardized "open" command cannot
+            # be utilized.
+            cmd = "%s %s &" % (app_path, app_args)
+
+        elif system == "darwin":
+            # on the mac, the executable paths are normally pointing
+            # to the application bundle and not to the binary file
+            # embedded in the bundle, meaning that we should use the
+            # built-in mac open command to execute it
+            cmd = "open -n \"%s\"" % (app_path)
+            if app_args:
+                cmd += " --args \"%s\"" % app_args.replace("\"", "\\\"")
+
+        elif system == "win32":
+            # on windows, we run the start command in order to avoid
+            # any command shells popping up as part of the application launch.
+            cmd = "start /B \"App\" \"%s\" %s" % (app_path, app_args)
+            shell_type = 'cmd'
+
+        # Execute App in a Rez context
+        if use_rez:
+            n_env = os.environ.copy()
+            proc = context.execute_shell(
+                command=cmd,
+                parent_environ=n_env,
+                shell=shell_type,
+                stdin=False,
+                block=False
+            )
+            exit_code = proc.wait()
+            context.print_info(verbosity=True)
+
+        else:
+            # run the command to launch the app
+            exit_code = os.system(cmd)
+
+        return {
+            "command": cmd,
+            "return_code": exit_code
+        }
+
+    def check_rez(self, strict=True):
+        """
+        Checks to see if a Rez package is available in the current environment.
+        If it is available, add it to the system path, exposing the Rez Python API
+
+        :param strict: (bool) If True, raise an error if Rez is not available as a package.
+                              This will prevent the app from being launched.
+
+        :returns: A path to the Rez package.
+        """
+        system = sys.platform
+        rez_cmd = "rez-python -c 'import rez; print(rez.__path__[0])'"
+        process = subprocess.Popen(rez_cmd, stdout=subprocess.PIPE, shell=True)
+        rez_path, err = process.communicate()
+
+        if err or not rez_path:
+            if strict:
+                raise ImportError("Failed to find Rez as a package in the current "
+                                  "environment! Try 'rez-bind rez'!")
+            else:
+                print("WARNING: Failed to find a Rez package in the current "
+                      "environment. Unable to request Rez packages.",
+                      file=sys.stderr)
+
+            rez_path = ""
+        else:
+            rez_path = rez_path.strip()
+            rez_path = os.path.dirname(rez_path)
+            print("Found Rez:", rez_path)
+            print("Adding Rez to system path...")
+            sys.path.append(rez_path)
+
+        return rez_path
+
+
+# Copyright 2013-2016 Allan Johns, Shotgun Software Inc.
+#
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.

--- a/tk-config-default2/env/includes/settings/tk-desktop.yml
+++ b/tk-config-default2/env/includes/settings/tk-desktop.yml
@@ -1,0 +1,59 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+################################################################################
+
+includes:
+- ../app_locations.yml
+- ../engine_locations.yml
+- ./tk-multi-launchapp.yml
+- ./tk-multi-publish2.yml
+- ./tk-multi-screeningroom.yml
+
+################################################################################
+
+# site
+settings.tk-desktop.site:
+  apps:
+  location: "@engines.tk-desktop.location"
+
+
+# project
+settings.tk-desktop.project:
+  apps:
+    tk-multi-pythonconsole:
+      location: "@apps.tk-multi-pythonconsole.location"
+    tk-multi-devutils:
+      location: "@apps.tk-multi-devutils.location"
+    tk-multi-launchapp: "@settings.tk-multi-launchapp"
+    tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+    tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+  groups:
+  - matches:
+    - "*Fla*"
+    - "*Houdini*"
+    - "*Mari*"
+    - "*Max*"
+    - "*Maya*"
+    - "*Motion*"
+    - "*Nuke*"
+    - "*Photoshop*"
+    - "*After*"
+    - "*Effects*"
+    name: Creative Tools
+  - matches:
+    - "*Hiero*"
+    name: Editorial Tools
+  location: "@engines.tk-desktop.location"

--- a/tk-config-default2/env/includes/settings/tk-desktop2.yml
+++ b/tk-config-default2/env/includes/settings/tk-desktop2.yml
@@ -1,0 +1,37 @@
+# Copyright (c) 2018 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+################################################################################
+
+includes:
+- ../app_locations.yml
+- ../engine_locations.yml
+- ./tk-multi-launchapp.yml
+- ./tk-multi-publish2.yml
+
+################################################################################
+
+# site
+settings.tk-desktop2.site:
+  apps:
+  location: "@engines.tk-desktop2.location"
+
+
+# project
+settings.tk-desktop2.all:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp"
+    tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+    tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+  location: "@engines.tk-desktop2.location"

--- a/tk-config-default2/env/includes/settings/tk-multi-launchapp.yml
+++ b/tk-config-default2/env/includes/settings/tk-multi-launchapp.yml
@@ -1,0 +1,87 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+################################################################################
+
+includes:
+- ../app_locations.yml
+- ../software_paths.yml
+
+################################################################################
+
+# auto discover DCCs for launch
+settings.tk-multi-launchapp:
+  use_software_entity: true
+  hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
+  location: "@apps.tk-multi-launchapp.location"
+
+# shotgun
+settings.tk-multi-launchapp.shotgun:
+  use_software_entity: true
+  skip_engine_instances: ["tk-nukestudio"]
+  hook_before_register_command: "{config}/tk-multi-launchapp/before_register_command.py"
+  location: "@apps.tk-multi-launchapp.location"
+
+################################################################################
+
+# app-specific launchapp configurations
+
+# hiero
+settings.tk-multi-launchapp.hiero:
+  engine: tk-hiero
+  icon: "{target_engine}/icon_hiero_256.png"
+  linux_path: "@path.linux.hiero"
+  linux_args: --hiero
+  mac_path: "@path.mac.hiero"
+  windows_path: "@path.windows.hiero"
+  windows_args: --hiero
+  menu_name: Hiero
+  location: "@apps.tk-multi-launchapp.location"
+
+# mari
+settings.tk-multi-launchapp.mari:
+  engine: tk-mari
+  linux_path: "@path.linux.mari"
+  mac_path: "@path.mac.mari"
+  windows_path: "@path.windows.mari"
+  menu_name: Mari
+  location: "@apps.tk-multi-launchapp.location"
+
+# motionbuilder
+settings.tk-multi-launchapp.motionbuilder:
+  engine: tk-motionbuilder
+  windows_path: "@path.windows.motionbuilder"
+  menu_name: MotionBuilder
+  location: "@apps.tk-multi-launchapp.location"
+
+# rez Maya 2019
+settings.tk-multi-launchapp.maya:
+  engine: tk-maya
+  extra:
+    rez:
+      packages:
+      - maya-2019
+      # # Optional, additional rez packages
+      # - studio_maya_tools-1.2
+      # - show_maya_tools-dev
+      parent_variables:
+      - PYTHONPATH
+      - MAYA_MODULE_PATH
+      - MAYA_SCRIPT_PATH
+  menu_name: "Maya 2019"
+  location: "@apps.tk-multi-launchapp.location"
+  # --- IMPORTANT ---
+  # Point to rez_app_launch.py hook location
+  hook_app_launch: "{config}/tk-multi-launchapp/rez_app_launch.py"
+  # What to run after entering "rez env maya" to launch Maya, e.g.
+  linux_path: "maya"
+  mac_path: "Maya.app"
+  windows_path: "maya.exe"
+

--- a/tk-config-default2/env/includes/settings/tk-shell.yml
+++ b/tk-config-default2/env/includes/settings/tk-shell.yml
@@ -1,0 +1,87 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+################################################################################
+
+includes:
+- ../app_locations.yml
+- ../engine_locations.yml
+- ./tk-multi-launchapp.yml
+- ./tk-multi-publish2.yml
+- ./tk-multi-screeningroom.yml
+
+################################################################################
+
+# asset
+settings.tk-shell.asset:
+  apps:
+    tk-multi-launchapp: '@settings.tk-multi-launchapp'
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+    tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+  location: '@engines.tk-shell.location'
+
+# asset_step
+settings.tk-shell.asset_step:
+  apps:
+    tk-multi-launchapp: '@settings.tk-multi-launchapp'
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+    tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+  location: '@engines.tk-shell.location'
+
+# project
+settings.tk-shell.project:
+  apps:
+    tk-multi-demo:
+      location: "@apps.tk-multi-demo.location"
+    tk-multi-launchapp: '@settings.tk-multi-launchapp'
+    tk-multi-launchhiero: '@settings.tk-multi-launchapp.hiero'
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+    tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+  location: '@engines.tk-shell.location'
+
+# sequence
+settings.tk-shell.sequence:
+  apps:
+    tk-multi-launchapp: '@settings.tk-multi-launchapp'
+    tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+  location: '@engines.tk-shell.location'
+
+# shot
+settings.tk-shell.shot:
+  apps:
+    tk-multi-launchapp: '@settings.tk-multi-launchapp'
+    tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+  location: '@engines.tk-shell.location'
+
+# shot_step
+settings.tk-shell.shot_step:
+  apps:
+    tk-multi-launchapp: '@settings.tk-multi-launchapp'
+    tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+  location: '@engines.tk-shell.location'

--- a/tk-config-default2/env/includes/settings/tk-shotgun.yml
+++ b/tk-config-default2/env/includes/settings/tk-shotgun.yml
@@ -1,0 +1,111 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+#
+
+################################################################################
+
+includes:
+- ../engine_locations.yml
+- ./tk-multi-launchapp.yml
+- ./tk-multi-publish2.yml
+- ./tk-multi-screeningroom.yml
+- ./tk-shotgun-folders.yml
+- ./tk-shotgun-launchfolder.yml
+- ./tk-shotgun-launchpublish.yml
+
+################################################################################
+
+# asset
+settings.tk-shotgun.asset:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp"
+    tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-folders: "@settings.tk-shotgun-folders"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"
+
+# asset_step
+settings.tk-shotgun.asset_step:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp.shotgun"
+    tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"
+
+# project
+settings.tk-shotgun.project:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp"
+    tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+    tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"
+
+# publishedfile_version
+settings.tk-shotgun.version:
+  apps:
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-launchpublish: "@settings.tk-shotgun-launchpublish"
+  location: "@engines.tk-shotgun.location"
+
+settings.tk-shotgun.publishedfile:
+  apps:
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-launchpublish: "@settings.tk-shotgun-launchpublish"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"
+
+# sequence
+settings.tk-shotgun.sequence:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-folders: "@settings.tk-shotgun-folders"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"
+
+# shot
+settings.tk-shotgun.shot:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-folders: "@settings.tk-shotgun-folders"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"
+
+# shot_step
+settings.tk-shotgun.shot_step:
+  apps:
+    tk-multi-launchapp: "@settings.tk-multi-launchapp.shotgun"
+    tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
+    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+    tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+    tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+    tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+    tk-shotgun-launchfolder: "@settings.tk-shotgun-launchfolder"
+  location: "@engines.tk-shotgun.location"

--- a/tk-config-default2/example-configs.patch
+++ b/tk-config-default2/example-configs.patch
@@ -1,0 +1,170 @@
+--- env/includes/settings/tk-multi-launchapp.yml	(revision ef7bba91d177407b0487816a696316cf4dafd6c2)
++++ env/includes/settings/tk-multi-launchapp.yml	(date 1576085431495)
+@@ -61,3 +61,26 @@
+   menu_name: MotionBuilder
+   location: "@apps.tk-multi-launchapp.location"
+
++# rez Maya 2019
++settings.tk-multi-launchapp.maya:
++  engine: tk-maya
++  extra:
++    rez:
++      packages:
++      - maya-2019
++      # # Optional, additional rez packages
++      # - studio_maya_tools-1.2
++      # - show_maya_tools-dev
++      parent_variables:
++      - PYTHONPATH
++      - MAYA_MODULE_PATH
++      - MAYA_SCRIPT_PATH
++  menu_name: "Maya 2019"
++  location: "@apps.tk-multi-launchapp.location"
++  # --- IMPORTANT ---
++  # Point to rez_app_launch.py hook location
++  hook_app_launch: "{config}/tk-multi-launchapp/rez_app_launch.py"
++  # What to run after entering "rez env maya" to launch Maya, e.g.
++  linux_path: "maya"
++  mac_path: "Maya.app"
++  windows_path: "maya.exe"
+Index: env/includes/settings/tk-shell.yml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- env/includes/settings/tk-shell.yml	(revision ef7bba91d177407b0487816a696316cf4dafd6c2)
++++ env/includes/settings/tk-shell.yml	(date 1576084718102)
+@@ -24,6 +24,7 @@
+ settings.tk-shell.asset:
+   apps:
+     tk-multi-launchapp: '@settings.tk-multi-launchapp'
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+     tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+@@ -34,6 +35,7 @@
+ settings.tk-shell.asset_step:
+   apps:
+     tk-multi-launchapp: '@settings.tk-multi-launchapp'
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+     tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+@@ -47,6 +49,7 @@
+       location: "@apps.tk-multi-demo.location"
+     tk-multi-launchapp: '@settings.tk-multi-launchapp'
+     tk-multi-launchhiero: '@settings.tk-multi-launchapp.hiero'
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmari: '@settings.tk-multi-launchapp.mari'
+     tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+@@ -58,6 +61,7 @@
+   apps:
+     tk-multi-launchapp: '@settings.tk-multi-launchapp'
+     tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+   location: '@engines.tk-shell.location'
+@@ -67,6 +71,7 @@
+   apps:
+     tk-multi-launchapp: '@settings.tk-multi-launchapp'
+     tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+   location: '@engines.tk-shell.location'
+@@ -76,6 +81,7 @@
+   apps:
+     tk-multi-launchapp: '@settings.tk-multi-launchapp'
+     tk-multi-launchmotionbuilder: '@settings.tk-multi-launchapp.motionbuilder'
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: '@settings.tk-multi-screeningroom.rv'
+   location: '@engines.tk-shell.location'
+Index: env/includes/settings/tk-shotgun.yml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- env/includes/settings/tk-shotgun.yml	(revision ef7bba91d177407b0487816a696316cf4dafd6c2)
++++ env/includes/settings/tk-shotgun.yml	(date 1576084718104)
+@@ -27,6 +27,7 @@
+   apps:
+     tk-multi-launchapp: "@settings.tk-multi-launchapp"
+     tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+@@ -39,6 +40,7 @@
+   apps:
+     tk-multi-launchapp: "@settings.tk-multi-launchapp.shotgun"
+     tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+@@ -51,6 +53,7 @@
+     tk-multi-launchapp: "@settings.tk-multi-launchapp"
+     tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+     tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+@@ -75,6 +78,7 @@
+ settings.tk-shotgun.sequence:
+   apps:
+     tk-multi-launchapp: "@settings.tk-multi-launchapp"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+@@ -86,6 +90,7 @@
+ settings.tk-shotgun.shot:
+   apps:
+     tk-multi-launchapp: "@settings.tk-multi-launchapp"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+@@ -98,6 +103,7 @@
+   apps:
+     tk-multi-launchapp: "@settings.tk-multi-launchapp.shotgun"
+     tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+Index: env/includes/settings/tk-desktop.yml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- env/includes/settings/tk-desktop.yml	(revision ef7bba91d177407b0487816a696316cf4dafd6c2)
++++ env/includes/settings/tk-desktop.yml	(date 1576084718097)
+@@ -36,6 +36,7 @@
+     tk-multi-launchapp: "@settings.tk-multi-launchapp"
+     tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+     tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+     tk-multi-screeningroom: "@settings.tk-multi-screeningroom.rv"
+Index: env/includes/settings/tk-desktop2.yml
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+--- env/includes/settings/tk-desktop2.yml	(revision ef7bba91d177407b0487816a696316cf4dafd6c2)
++++ env/includes/settings/tk-desktop2.yml	(date 1576084718094)
+@@ -31,6 +31,7 @@
+     tk-multi-launchapp: "@settings.tk-multi-launchapp"
+     tk-multi-launchhiero: "@settings.tk-multi-launchapp.hiero"
+     tk-multi-launchmari: "@settings.tk-multi-launchapp.mari"
++    tk-multi-launchmaya: "@settings.tk-multi-launchapp.maya"  # Added this for rez Maya 2019!
+     tk-multi-launchmotionbuilder: "@settings.tk-multi-launchapp.motionbuilder"
+     tk-multi-publish2: "@settings.tk-multi-publish2.standalone"
+   location: "@engines.tk-desktop2.location"
+\ No newline at end of file

--- a/tk-config-default2/hooks/tk-multi-launchapp/rez_app_launch.py
+++ b/tk-config-default2/hooks/tk-multi-launchapp/rez_app_launch.py
@@ -1,0 +1,202 @@
+"""tk-config-default2 hook to run applications, potentially in a Rez context.
+
+Please note that this requires Rez to be installed as a package,
+which exposes the Rez Python API. With a proper Rez installation, you can do
+this by running ``rez-bind rez``.
+"""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import os
+from pprint import pformat
+import subprocess
+import sys
+from tempfile import NamedTemporaryFile, TemporaryFile
+
+import sgtk
+
+HookBaseClass = sgtk.get_hook_baseclass()
+
+
+class AppLaunch(HookBaseClass):
+    """Hook to run an application."""
+
+    def execute(self, app_path, app_args, version, **kwargs):
+        """Start the required application using rez if required.
+
+        Notes:
+            - Define variables used to bootstrap tank from overwrite on
+              first reference
+            - Define others within ``tk-multi-launchapp.yml`` file in the
+              ``extra:rez:parent_variables`` list.
+
+        Args:
+            app_path (str):
+                The path of the application executable
+            app_args (str):
+                Any arguments the application may require
+            version (str):
+                version of the application being run if set in the "versions"
+                settings of the Launcher instance, otherwise ``None``
+
+        Returns:
+            dict[str]:
+                Execute results mapped to 'command' (str) and
+                'return_code' (int).
+        """
+        multi_launchapp = self.parent
+        rez_info = multi_launchapp.get_setting("extra", {}).get("rez", {})
+        cmd, shell_type = self.background_cmd_shell_type(app_path, app_args)
+
+        # Execute App in a Rez context
+        rez_py_path = self.get_rez_path()
+        if rez_py_path:
+            if rez_py_path not in sys.path:
+                self.logger.debug('Appending to sys.path: "%s"', rez_py_path)
+                sys.path.append(rez_py_path)
+
+            # Only import after rez_py_path is inside sys.path
+            from rez.resolved_context import ResolvedContext
+            from rez.config import config
+            rez_parent_variables = rez_info.get("parent_variables", [])
+            rez_packages = rez_info.get("packages", [])
+            self.logger.debug("rez parent variables: %s", rez_parent_variables)
+            self.logger.debug("rez packages: %s", rez_packages)
+
+            config.parent_variables = rez_parent_variables
+            context = ResolvedContext(rez_packages)
+            current_env = os.environ.copy()
+
+            env_kwargs = {'suffix': '-prev-env.py', 'delete': False}
+            with NamedTemporaryFile(mode='w+', **env_kwargs) as env_file:
+                env_file.write(pformat(current_env))
+                self.logger.debug(
+                    'Copied existing env for rez. See: "%s"',
+                    env_file.name
+                    )
+
+            with TemporaryFile(mode='w+') as info_buffer:
+                context.print_info(buf=info_buffer)
+                info_buffer.seek(0)
+                self.logger.debug(
+                    "Executing in rez context [%s]: %s\n%s",
+                    shell_type,
+                    cmd,
+                    info_buffer.read(),
+                    )
+
+            launcher_process = context.execute_shell(
+                command=cmd,
+                parent_environ=current_env,
+                shell=shell_type,
+                stdin=False,
+                block=False
+                )
+            exit_code = launcher_process.wait()
+        else:
+            # run the command to launch the app
+            exit_code = subprocess.check_call(cmd)
+
+        return {"command": cmd, "return_code": exit_code}
+
+    def background_cmd_shell_type(self, app_path, app_args):
+        """Make command string and shell type name for current environment.
+
+        Args:
+            app_path (str): The path of the application executable.
+            app_args (str): Any arguments the application may require.
+
+        Returns:
+            str, str: Command to run and (rez) shell type to run in.
+        """
+        system = sys.platform
+        shell_type = 'bash'
+
+        if system.startswith("linux"):
+            # on linux, we just run the executable directly
+            cmd_template = "{path} {flattened_args} &"
+
+        elif self.parent.get_setting("engine") in ["tk-flame", "tk-flare"]:
+            # flame and flare works in a different way from other DCCs
+            # on both linux and mac, they run unix-style command line
+            # and on the mac the more standardized "open" command cannot
+            # be utilized.
+            cmd_template = "{path} {flattened_args} &"
+
+        elif system == "darwin":
+            # on the mac, the executable paths are normally pointing
+            # to the application bundle and not to the binary file
+            # embedded in the bundle, meaning that we should use the
+            # built-in mac open command to execute it
+            cmd_template = 'open -n "{path}"'
+            if app_args:
+                app_args = app_args.replace('"', r'\"')
+                cmd_template += ' --args "{flattened_args}"'
+
+        elif system == "win32":
+            # on windows, we run the start command in order to avoid
+            # any command shells popping up as part of the application launch.
+            cmd_template = 'start /B "App" "{path}" {flattened_args}'
+
+        else:
+            error = (
+                'No cmd (formatting) and shell_type implemented for "%s":\n'
+                '- app_path:"%s"\n'
+                '- app_args:"%s"'
+            )
+            raise NotImplementedError(error % (system, app_path, app_args))
+
+        cmd = cmd_template.format(path=app_path, flattened_args=app_args)
+        return cmd, shell_type
+
+    def get_rez_path(self, strict=True):
+        """Get ``rez`` python package path from the current environment.
+
+        Args:
+            strict (bool):
+                Whether to raise an error if Rez is not available as a package.
+                This will prevent the app from being launched.
+
+        Returns:
+            str: A path to the Rez package, can be empty if ``strict=False``..
+        """
+        rez_cmd = "rez-python -c 'import rez; print(rez.__path__[0])'"
+        process = subprocess.Popen(rez_cmd, stdout=subprocess.PIPE, shell=True)
+        rez_python_path, err = process.communicate()
+
+        if err or not rez_python_path:
+            if strict:
+                raise ImportError(
+                    "Failed to find Rez as a package in the current "
+                    "environment! Try 'rez-bind rez'!"
+                    )
+            else:
+                self.logger.warn(
+                    "Failed to find a Rez package in the current "
+                    "environment. Unable to request Rez packages."
+                    )
+
+            rez_python_path = ""
+        else:
+            absolute_path = os.path.abspath(rez_python_path.strip())
+            rez_python_path = os.path.dirname(absolute_path)
+            self.logger.debug("Found Rez in: %s", rez_python_path)
+
+        return rez_python_path
+
+
+# Copyright 2013-2016 Allan Johns, Shotgun Software Inc.
+#
+# This library is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either
+# version 3 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
Contribute our in-house, updated Shotgun `rez_app_launch` hook designed for `tk-config-default2`.

Changes made by:
- @Liametc
- @j0yu

> Google Groups discussion: https://groups.google.com/forum/#!topic/rez-config/BSRuFNxBAkk

**See Also**

Original [PR 823](https://github.com/nerdvegas/rez/pull/823) and [Issue 822](https://github.com/nerdvegas/rez/issues/822) from official Rez repository
Files at last commit of the PR: [2be03b01](https://github.com/nerdvegas/rez/tree/2be03b0149467562ebd53eb68061e14dea3baf84)


**~~To Do~~ After initial release**

- See #2 ~~Auto changelog and release notes~~ 
  - ~~Test https://pypi.org/project/changelog-cli/ using in Docker python image~~
- ~~Build sphinx docs for the hooks only~~ See #3
  - ~~Test GitHub actions for setting up `gh-pages`~~
-----

This hook is executed to launch applications, potentially in a Rez context.

It is **NOT** official/supported by Shotgun Software, but by
[third-party contributors](/AUTHORS.md)

Please note that this requires Rez to be installed as a package, i.e.
able to `rez env rez`, which exposes the Rez Python API.

With a proper Rez installation, you can do this by running `rez-bind rez`.


To keep a copy of the original `rez_app_launch.py`, there are 2 variants
available:

- [tk-config-default2][] is the latest pipeline configuration style

  - Currently supported by Shotgun Software
  - Will be targeting this going forward for `rez_app_launch.py`

- [tk-config-default][] is the legacy pipeline configuration style

  - Less supported by Shotgun Software
  - The original `rez_app_launch.py`, only updated to keep it functional

> As of writing, the 2 `rez_app_launch.py` was tested at [WWFX UK][]
> using [rez 2.28.0][]. Newer `rez` versions may be tested in the future.



[patch]: https://www.gnu.org/software/diffutils/manual/html_mono/diff.html#Invoking%20patch
[rez 2.28.0]: https://github.com/nerdvegas/rez/releases/tag/2.28.0
[tk-desktop2]: https://github.com/shotgunsoftware/tk-desktop2
[tk-desktop]: https://github.com/shotgunsoftware/tk-desktop
[tk-shotgun]: https://github.com/shotgunsoftware/tk-shotgun
[tk-shell]: https://github.com/shotgunsoftware/tk-shell
[tk-config-default]: https://github.com/shotgunsoftware/tk-config-default
[tk-config-default v0.18.2]: https://github.com/shotgunsoftware/tk-config-default/releases/tag/v0.18.2
[tk-config-default2]: https://github.com/shotgunsoftware/tk-config-default2
[tk-config-default2 v1.2.11]: https://github.com/shotgunsoftware/tk-config-default2/releases/tag/v1.2.11
[WWFX UK]: https://github.com/wwfxuk

